### PR TITLE
ENH: Add 'FMUDirectory' class

### DIFF
--- a/src/fmu/settings/__init__.py
+++ b/src/fmu/settings/__init__.py
@@ -6,3 +6,7 @@ try:
     __version__ = version
 except ImportError:
     __version__ = version = "0.0.0"
+
+from ._fmu_dir import FMUDirectory, find_nearest_fmu_directory, get_fmu_directory
+
+__all__ = ["get_fmu_directory", "FMUDirectory", "find_nearest_fmu_directory"]

--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -1,0 +1,290 @@
+"""Main interface for working with .fmu directory."""
+
+import json
+from pathlib import Path
+from typing import Any, Final, Self, cast
+
+from ._init import write_fmu_config
+from ._logging import null_logger
+from .models.config import Config
+
+logger: Final = null_logger(__name__)
+
+
+class FMUDirectory:
+    """Provides access to a .fmu directory and operations on its contents."""
+
+    def __init__(
+        self: Self,
+        base_path: str | Path,
+        search_parents: bool = True,
+    ) -> None:
+        """Initializes access to a .fmu directory.
+
+        Args:
+            base_path: The directory containing the .fmu directory or one of its parent
+                       dirs
+            search_parents: If True, searches parent directories for .fmu if not found
+
+        Raises:
+            FileNotFoundError: If .fmu directory doesn't exist
+            PermissionError: If lacking permissions to read/write to the directory
+        """
+        self.base_path = Path(base_path).resolve()
+
+        self._path: Path | None = None
+        if search_parents:
+            self._path = self.find_fmu_directory(self.base_path)
+        else:
+            fmu_dir = self.base_path / ".fmu"
+            if fmu_dir.is_dir():
+                self._path = fmu_dir
+
+        if self._path is None:
+            if search_parents:
+                raise FileNotFoundError(
+                    f"No .fmu directory found at or above {self.base_path}"
+                )
+            raise FileNotFoundError(f"No .fmu directory found at {self.base_path}")
+
+        self._config_cache: Config | None = None
+        logger.debug(f"Using .fmu directory at {self._path}")
+
+    @property
+    def path(self: Self) -> Path:
+        """Returns the path to the .fmu directory."""
+        return cast("Path", self._path)
+
+    @staticmethod
+    def find_fmu_directory(start_path: Path) -> Path | None:
+        """Searches for a .fmu directory in start_path and its parents.
+
+        Args:
+            start_path: The path to start searching from
+
+        Returns:
+            Path to the found .fmu directory or None if not found
+        """
+        current = start_path
+        # Prevent symlink loops
+        visited = set()
+
+        while current not in visited:
+            visited.add(current)
+            fmu_dir = current / ".fmu"
+
+            if fmu_dir.is_dir():
+                return fmu_dir
+
+            # We hit root
+            if current == current.parent:
+                break
+
+            current = current.parent
+
+        return None
+
+    def get_config(self) -> Config:
+        """Returns the current configuration.
+
+        Returns:
+            A Pydantic Config object
+
+        Raises:
+            FileNotFoundError: If config.json doesn't exist
+            ValueError: If config.json cannot be parsed
+        """
+        if self._config_cache is None:
+            config_path = self.path / "config.json"
+
+            if not config_path.exists():
+                raise FileNotFoundError(f"Config file not found at '{config_path}'")
+
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    config_data = json.load(f)
+                self._config_cache = Config.model_validate(config_data)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in config file: {e}") from e
+
+        return self._config_cache
+
+    def update_config(self, updates: dict[str, Any]) -> Config:
+        """Updates the configuration with the given values.
+
+        Args:
+            updates: Dictionary of values to update in the config
+
+        Returns: The updated Config object
+
+        Raises:
+            ValueError: If updates contain invalid values
+        """
+        config = self.get_config()
+
+        config_dict = config.model_dump()
+        config_dict.update(updates)
+
+        updated_config = Config.model_validate(config_dict)
+        write_fmu_config(self.path, updated_config)
+        self._config_cache = updated_config
+
+        return updated_config
+
+    def get_file_path(self, relative_path: str | Path) -> Path:
+        """Gets the absolute path to a file within the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+
+        Returns:
+            Absolute path to the file
+        """
+        return self.path / relative_path
+
+    def read_file(self, relative_path: str | Path) -> bytes:
+        """Reads a file from the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+
+        Returns:
+            File contents as bytes
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist
+        """
+        file_path = self.get_file_path(relative_path)
+        return file_path.read_bytes()
+
+    def read_text_file(self, relative_path: str | Path, encoding: str = "utf-8") -> str:
+        """Reads a text file from the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+            encoding: Text encoding to use. Default utf-8
+
+        Returns:
+            File contents as string
+        """
+        file_path = self.get_file_path(relative_path)
+        return file_path.read_text(encoding=encoding)
+
+    def write_file(self, relative_path: str | Path, data: bytes) -> None:
+        """Writes bytes to a file in the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+            data: Bytes to write
+        """
+        file_path = self.get_file_path(relative_path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        file_path.write_bytes(data)
+        logger.debug(f"Wrote {len(data)} bytes to {file_path}")
+
+    def write_text_file(
+        self, relative_path: str | Path, content: str, encoding: str = "utf-8"
+    ) -> None:
+        """Writes text to a file in the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+            content: Text content to write
+            encoding: Text encoding to use. Default utf-8
+        """
+        file_path = self.get_file_path(relative_path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        file_path.write_text(content, encoding=encoding)
+        logger.debug(f"Wrote text file to {file_path}")
+
+    def list_files(self, subdirectory: str | Path | None = None) -> list[Path]:
+        """Lists files in the .fmu directory or a subdirectory.
+
+        Args:
+            subdirectory: Optional subdirectory to list files from
+
+        Returns:
+            List of Path objects for files (not directories)
+        """
+        base = self.get_file_path(subdirectory) if subdirectory else self.path
+        if not base.exists():
+            return []
+
+        return [p for p in base.iterdir() if p.is_file()]
+
+    def ensure_directory(self, relative_path: str | Path) -> Path:
+        """Ensures a subdirectory exists in the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+
+        Returns:
+            Path to the directory
+        """
+        dir_path = self.get_file_path(relative_path)
+        dir_path.mkdir(parents=True, exist_ok=True)
+        return dir_path
+
+    def file_exists(self, relative_path: str | Path) -> bool:
+        """Checks if a file exists in the .fmu directory.
+
+        Args:
+            relative_path: Path relative to the .fmu directory
+
+        Returns:
+            True if the file exists, False otherwise
+        """
+        return self.get_file_path(relative_path).exists()
+
+    @classmethod
+    def find_nearest(
+        cls: type["FMUDirectory"], start_path: str | Path = "."
+    ) -> "FMUDirectory":
+        """Factory method to find and open the nearest .fmu directory.
+
+        Args:
+            start_path: Path to start searching from. Default current working director
+
+        Returns:
+            FMUDirectory instance
+
+        Raises:
+            FileNotFoundError: If no .fmu directory is found
+        """
+        return cls(start_path, search_parents=True)
+
+
+def get_fmu_directory(base_path: Path, search_parents: bool = True) -> FMUDirectory:
+    """Initializes access to a .fmu directory.
+
+    Args:
+        base_path: The directory containing the .fmu directory or one of its parent
+                   dirs
+        search_parents: If True, searches parent directories for .fmu if not found
+
+    Returns:
+        FMUDirectory instance
+
+    Raises:
+        FileNotFoundError: If .fmu directory doesn't exist
+        PermissionError: If lacking permissions to read/write to the directory
+
+    """
+    return FMUDirectory(base_path, search_parents=search_parents)
+
+
+def find_nearest_fmu_directory(start_path: str | Path = ".") -> FMUDirectory:
+    """Factory method to find and open the nearest .fmu directory.
+
+    Args:
+        start_path: Path to start searching from. Default current working directory
+
+    Returns:
+        FMUDirectory instance
+
+    Raises:
+        FileNotFoundError: If no .fmu directory is found
+    """
+    return FMUDirectory.find_nearest(start_path)

--- a/src/fmu/settings/_init.py
+++ b/src/fmu/settings/_init.py
@@ -6,9 +6,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
-from fmu.settings import __version__
-
 from ._logging import null_logger
+from ._version import __version__
 from .models.config import Config
 
 logger: Final = null_logger(__name__)
@@ -46,7 +45,7 @@ def _create_fmu_config(
         config = Config.model_validate(config_data)
 
     if config.created_by != user:
-        logger.warn(
+        logger.warning(
             f"Config created_by is '{config.created_by}' but current user is '{user}'"
         )
 
@@ -88,7 +87,7 @@ def _create_fmu_directory(base_path: Path) -> Path:
     return fmu_dir
 
 
-def _write_fmu_config(fmu_dir: Path, config: Config) -> Path:
+def write_fmu_config(fmu_dir: Path, config: Config) -> Path:
     """Writes the configuration file to .fmu/config.json.
 
     Args:
@@ -140,7 +139,7 @@ def init_fmu_directory(
 
     fmu_dir = _create_fmu_directory(base_path)
     config = _create_fmu_config(config_data)
-    _write_fmu_config(fmu_dir, config)
+    write_fmu_config(fmu_dir, config)
 
     logger.debug(f"Successfully initialized .fmu directory at '{fmu_dir}'")
     return fmu_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,15 @@
 """Root configuration for pytest."""
 
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import pytest
 from pytest_lazy_fixtures import lf
 
-from fmu.settings import __version__
+from fmu.settings._fmu_dir import FMUDirectory
+from fmu.settings._init import init_fmu_directory
+from fmu.settings._version import __version__
 from fmu.settings.models.config import Config
 
 
@@ -36,3 +39,15 @@ def config_model(config_dict: dict[str, Any]) -> Config:
 def config_data_options(request: pytest.FixtureRequest) -> pytest.FixtureRequest:
     """Possible configuration inputs used when generating a new .fmu directory."""
     return request.param
+
+
+@pytest.fixture
+def fmu_dir_path(tmp_path: Path, config_model: Config) -> Path:
+    """Create a temporary FMU directory for testing."""
+    return init_fmu_directory(tmp_path, config_model)
+
+
+@pytest.fixture
+def fmu_dir(fmu_dir_path: Path) -> FMUDirectory:
+    """Create an FMUDirectory instance for testing."""
+    return FMUDirectory(fmu_dir_path.parent, search_parents=False)

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -1,0 +1,251 @@
+"""Tests for the FMUDirectory class."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from pytest import MonkeyPatch
+
+from fmu.settings import find_nearest_fmu_directory, get_fmu_directory
+from fmu.settings._fmu_dir import FMUDirectory
+from fmu.settings.models.config import Config
+
+
+def test_init_existing_directory(fmu_dir: FMUDirectory) -> None:
+    """Tests initializing an FMUDirectory on an existing .fmu directory."""
+    fmu = FMUDirectory(fmu_dir.base_path, search_parents=False)
+    assert fmu.path == fmu_dir.path
+    assert fmu.base_path == fmu_dir.base_path
+
+
+def test_get_fmu_directory(fmu_dir: FMUDirectory) -> None:
+    """Tests initializing an FMUDirectory via get_fmu_directory."""
+    fmu = get_fmu_directory(fmu_dir.base_path, search_parents=False)
+    assert fmu.path == fmu_dir.path
+    assert fmu.base_path == fmu_dir.base_path
+
+
+def test_init_on_missing_directory(tmp_path: Path) -> None:
+    """Tests initializing with a missing directory raises."""
+    with pytest.raises(
+        FileNotFoundError, match=f"No .fmu directory found at {tmp_path}"
+    ):
+        FMUDirectory(tmp_path, search_parents=False)
+
+
+def test_init_search_parents(fmu_dir: FMUDirectory) -> None:
+    """Tests initializing with search_parents=True."""
+    subdir = fmu_dir.base_path / "subdir"
+    subdir.mkdir()
+
+    fmu = FMUDirectory(subdir, search_parents=True)
+    assert fmu.path == fmu_dir.path
+    assert fmu.base_path == subdir
+
+
+def test_init_search_parents_on_missing_directory(tmp_path: Path) -> None:
+    """Tests initializing with a missing directory raises."""
+    with pytest.raises(
+        FileNotFoundError, match=f"No .fmu directory found at or above {tmp_path}"
+    ):
+        FMUDirectory(tmp_path, search_parents=True)
+
+
+def test_find_fmu_directory(fmu_dir: FMUDirectory) -> None:
+    """Tests find_fmu_directory method on nested children."""
+    child = fmu_dir.base_path / "child"
+    grand_child = child / "grandchild"
+    grand_child.mkdir(parents=True)
+
+    found_dir = FMUDirectory.find_fmu_directory(grand_child)
+    assert found_dir == fmu_dir.path
+
+
+def test_find_fmu_directory_not_found(tmp_path: Path) -> None:
+    """Tests find_fmu_directory() returns None if no .fmu found."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    found_dir = FMUDirectory.find_fmu_directory(empty_dir)
+    assert found_dir is None
+
+
+def test_find_nearest(fmu_dir: FMUDirectory) -> None:
+    """Test find_nearest factory method."""
+    subdir = fmu_dir.base_path / "subdir"
+    subdir.mkdir()
+
+    fmu = FMUDirectory.find_nearest(subdir)
+    assert fmu.path == fmu_dir.path
+
+
+def test_find_nearest_fmu_directory(fmu_dir: FMUDirectory) -> None:
+    """Test find_nearest factory method."""
+    subdir = fmu_dir.base_path / "subdir"
+    subdir.mkdir()
+
+    fmu = find_nearest_fmu_directory(subdir)
+    assert fmu.path == fmu_dir.path
+
+
+def test_find_nearest_not_found(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Test find_nearest raises FileNotFoundError when not found."""
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(
+        FileNotFoundError, match=f"No .fmu directory found at or above {tmp_path}"
+    ):
+        FMUDirectory.find_nearest()
+    with pytest.raises(
+        FileNotFoundError, match=f"No .fmu directory found at or above {tmp_path}"
+    ):
+        FMUDirectory.find_nearest(tmp_path)
+
+
+def test_get_config(fmu_dir: FMUDirectory, config_model: Config) -> None:
+    """Tests get_config returns the correct config."""
+    config = fmu_dir.get_config()
+    assert config == config_model
+
+
+def test_get_config_missing_file(tmp_path: Path) -> None:
+    """Tests get_config raises FileNotFoundError when config.json missing."""
+    empty_fmu_dir = tmp_path / ".fmu"
+    empty_fmu_dir.mkdir()
+
+    fmu = FMUDirectory(tmp_path, search_parents=False)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=f"Config file not found at '{empty_fmu_dir}/config.json'",
+    ):
+        fmu.get_config()
+
+
+def test_get_config_invalid_json(fmu_dir: FMUDirectory) -> None:
+    """Tests a corrupted config.json raises ValueError."""
+    config_path = fmu_dir.path / "config.json"
+    with open(config_path, "a", encoding="utf-8") as f:
+        f.write("%")
+
+    with pytest.raises(ValueError, match="Invalid JSON in config file"):
+        fmu_dir.get_config()
+
+
+def test_update_config(fmu_dir: FMUDirectory) -> None:
+    """Tests update_config updates and saves the config."""
+    updated_config = fmu_dir.update_config({"version": "2.0.0"})
+
+    assert updated_config.version == "2.0.0"
+    assert fmu_dir._config_cache is not None
+    assert fmu_dir._config_cache.version == "2.0.0"
+
+    config_file = fmu_dir.path / "config.json"
+    with open(config_file, encoding="utf-8") as f:
+        saved_config = json.load(f)
+
+    assert saved_config["version"] == "2.0.0"
+
+
+def test_update_config_invalid_data(fmu_dir: FMUDirectory) -> None:
+    """Tests that update_config raises ValidationError on bad data."""
+    with pytest.raises(ValidationError, match="version"):
+        fmu_dir.update_config({"version": 123})
+
+
+def test_get_file_path(fmu_dir: FMUDirectory) -> None:
+    """Tests get_file_path returns correct path."""
+    path = fmu_dir.get_file_path("test.txt")
+    assert path == fmu_dir.path / "test.txt"
+
+
+def test_file_exists(fmu_dir: FMUDirectory) -> None:
+    """Tests file_exists returns correct boolean."""
+    test_file = fmu_dir.path / "exists.txt"
+    test_file.touch()
+
+    assert fmu_dir.file_exists("exists.txt") is True
+    assert fmu_dir.file_exists("doesnt.txt") is False
+
+
+def test_read_file(fmu_dir: FMUDirectory) -> None:
+    """Tests read_file reads bytes correctly."""
+    test_file = fmu_dir.path / "bin.dat"
+    test_data = b"test bin data"
+    test_file.write_bytes(test_data)
+
+    data = fmu_dir.read_file("bin.dat")
+    assert data == test_data
+
+
+def test_read_file_not_found(fmu_dir: FMUDirectory) -> None:
+    """Tests read_file raises FileNotFoundError for missing files."""
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        fmu_dir.read_file("not_real.txt")
+
+
+def test_read_text_file(fmu_dir: FMUDirectory) -> None:
+    """Tests read_text_file reads text correctly."""
+    test_file = fmu_dir.path / "text.txt"
+    test_text = "test text data å"
+    test_file.write_text(test_text)
+
+    text = fmu_dir.read_text_file("text.txt")
+    assert text == test_text
+
+
+def test_write_text_file(fmu_dir: FMUDirectory) -> None:
+    """Tests write_text_file writes text correctly."""
+    test_text = "new text data æ"
+    fmu_dir.write_text_file("new_text.txt", test_text)
+
+    file_path = fmu_dir.path / "new_text.txt"
+    assert file_path.exists()
+    assert file_path.read_text() == test_text
+
+
+def test_write_file_creates_dir(fmu_dir: FMUDirectory) -> None:
+    """Tests write_file creates parent directories."""
+    test_data = b"nested data"
+    fmu_dir.write_file("nested/dir/file.dat", test_data)
+
+    nested_dir = fmu_dir.path / "nested" / "dir"
+    assert nested_dir.is_dir()
+
+    file_path = nested_dir / "file.dat"
+    assert file_path.exists()
+    assert file_path.read_bytes() == test_data
+
+
+def test_list_files(fmu_dir: FMUDirectory) -> None:
+    """Tests that list_files returns the correct files."""
+    (fmu_dir.path / "file1.txt").touch()
+    (fmu_dir.path / "file2.txt").touch()
+
+    subdir = fmu_dir.path / "subdir"
+    subdir.mkdir()
+    (subdir / "file3.txt").touch()
+
+    files = fmu_dir.list_files()
+    filenames = [f.name for f in files]
+
+    assert "file1.txt" in filenames
+    assert "file2.txt" in filenames
+    assert "config.json" in filenames
+
+    assert "file3.txt" not in filenames
+
+    subdir_files = fmu_dir.list_files("subdir")
+    assert len(subdir_files) == 1
+    assert subdir_files[0].name == "file3.txt"
+
+    not_subdir_files = fmu_dir.list_files("not_subdir")
+    assert not_subdir_files == []
+
+
+def test_ensure_directory(fmu_dir: FMUDirectory) -> None:
+    """Tests that ensure_directory creates directories."""
+    dir_path = fmu_dir.ensure_directory("nested/test/dir")
+    assert dir_path.exists()
+    assert dir_path.is_dir()
+    assert dir_path == fmu_dir.path / "nested" / "test" / "dir"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,8 +13,8 @@ from fmu.settings import __version__
 from fmu.settings._init import (
     _create_fmu_config,
     _create_fmu_directory,
-    _write_fmu_config,
     init_fmu_directory,
+    write_fmu_config,
 )
 from fmu.settings.models.config import Config
 
@@ -91,7 +91,7 @@ def test_make_fmu_directory(tmp_path: Path) -> None:
 
 def test_write_fmu_config_roundtrip(tmp_path: Path, config_model: Config) -> None:
     """Tests that the FMU config writes correctly."""
-    config_path = _write_fmu_config(tmp_path, config_model)
+    config_path = write_fmu_config(tmp_path, config_model)
     assert str(config_path).endswith("config.json")
     with open(config_path, encoding="utf-8") as f:
         config_data = json.loads(f.read())


### PR DESCRIPTION
Resolves #2

A first implementation at the interface other packages have with .fmu. Possibly needs file locking when working with config.json; will add in a follow-up PR.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
