### PR TITLE
ENH: Add PydanticResourceManager

### DIFF
--- a/src/fmu/settings/resources/managers.py
+++ b/src/fmu/settings/resources/managers.py
@@ -1,0 +1,96 @@
+"""Contains the base class used for interacting with resources."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    # Avoid circular dependency for type hint in __init__ only
+    from fmu.settings._fmu_dir import FMUDirectory
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class PydanticResourceManager(Generic[T]):
+    """Base class for managing resources represented by Pydantic models."""
+
+    def __init__(self: Self, fmu_dir: FMUDirectory, model_class: type[T]) -> None:
+        """Initializes the resource manager.
+
+        Args:
+            fmu_dir: The FMUDirectory instance
+            model_class: The Pydantic model class this manager handles
+        """
+        self.fmu_dir = fmu_dir
+        self.model_class = model_class
+        self._cache: T | None = None
+
+    @property
+    def relative_path(self: Self) -> Path:
+        """Returns the path to the resource file _inside_ the .fmu directory.
+
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    @property
+    def path(self: Self) -> Path:
+        """Returns the full path to the resource file."""
+        return self.fmu_dir.get_file_path(self.relative_path)
+
+    @property
+    def exists(self: Self) -> bool:
+        """Returns whether or not the resource exists."""
+        return self.path.exists()
+
+    def load(self: Self, force: bool = False) -> T:
+        """Loads the resources from disk and validates it as a Pydantic model.
+
+        Args:
+            force: Force a re-read even if the file is already cached
+
+        Returns:
+            Validated Pydantic model
+
+        Raises:
+            FileNotFoundError: If the resource file doesn't exist
+            ValidationError: If the data doesn't match the model schema
+        """
+        if self._cache is None or force:
+            if not self.exists:
+                raise FileNotFoundError(
+                    f"Resource file for '{self.__class__.__name__}' not found "
+                    f"at: '{self.path}'"
+                )
+
+            try:
+                content = self.fmu_dir.read_text_file(self.relative_path)
+                data = json.loads(content)
+                self._cache = self.model_class.model_validate(data)
+            except ValidationError as e:
+                raise ValueError(
+                    f"Invalid content in resource file for '{self.__class__.__name__}: "
+                    f"'{e}"
+                ) from e
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"Invalid JSON in resource file for '{self.__class__.__name__}': "
+                    f"'{e}'"
+                ) from e
+
+        return self._cache
+
+    def save(self: Self, model: T) -> None:
+        """Save the Pydantic model to disk.
+
+        Args:
+            model: Validated Pydantic model instance
+        """
+        json_data = model.model_dump_json(by_alias=True, indent=2)
+        self.fmu_dir.write_text_file(self.relative_path, json_data)
+        self._cache = model

--- a/tests/test_resources/test_resource_managers.py
+++ b/tests/test_resources/test_resource_managers.py
@@ -1,0 +1,104 @@
+"""Tests for fmu.settings.resources.managers."""
+
+import json
+from pathlib import Path
+from typing import Self
+
+import pytest
+from pydantic import BaseModel
+
+from fmu.settings._fmu_dir import FMUDirectory
+from fmu.settings.resources.managers import PydanticResourceManager
+
+
+class A(BaseModel):
+    """A test Pydantic class."""
+
+    foo: str
+
+
+class AManager(PydanticResourceManager[A]):
+    """A test Pydantic resource manager."""
+
+    def __init__(self: Self, fmu_dir: FMUDirectory) -> None:
+        """Initializer."""
+        super().__init__(fmu_dir, A)
+
+    @property
+    def relative_path(self: Self) -> Path:
+        """Relative path."""
+        return Path("foo.json")
+
+
+def test_pydantic_resource_manager_implementation(fmu_dir: FMUDirectory) -> None:
+    """Tests that derived classes must implement 'relative_path'."""
+
+    class Manager(PydanticResourceManager[A]):
+        """A test Pydantic resource manager."""
+
+        def __init__(self: Self, fmu_dir: FMUDirectory) -> None:
+            """Initializer."""
+            super().__init__(fmu_dir, A)
+
+    manager = Manager(fmu_dir)
+    with pytest.raises(NotImplementedError):
+        _ = manager.relative_path
+
+
+def test_pydantic_resource_manager_init(fmu_dir: FMUDirectory) -> None:
+    """Tests that initialization of a Pydantic resource manager is as expected."""
+    a = AManager(fmu_dir)
+    assert a.fmu_dir == fmu_dir
+    assert a.model_class == A
+
+    a_path = fmu_dir.path / "foo.json"
+    assert a.path == a_path
+    assert a.exists is False
+    assert a._cache is None
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=f"Resource file for 'AManager' not found at: '{a_path}'",
+    ):
+        a.load()
+
+
+def test_pydantic_resource_manager_save(fmu_dir: FMUDirectory) -> None:
+    """Tests saving a Pydantic resource that does not yet exist."""
+    a = AManager(fmu_dir)
+    a_model = A(foo="bar")
+
+    a.save(a_model)
+
+    assert a.exists
+    assert a._cache == a_model
+    with open(a.path, encoding="utf-8") as f:
+        a_dict = json.loads(f.read())
+
+    assert a_model == A.model_validate(a_dict)
+
+
+def test_pydantic_resource_manager_load(fmu_dir: FMUDirectory) -> None:
+    """Tests loading a Pydantic resource."""
+    a = AManager(fmu_dir)
+    a_model = A(foo="bar")
+    a.save(a_model)
+    assert a.load() == a_model
+    assert a._cache == a_model
+
+
+def test_pydantic_resource_manager_loads_invalid_model(fmu_dir: FMUDirectory) -> None:
+    """Tests loading a Pydantic resource."""
+    a = AManager(fmu_dir)
+    a_model = A(foo="bar")
+    a.save(a_model)
+
+    a_dict = a_model.model_dump()
+    a_dict["foo"] = 0
+
+    fmu_dir.write_text_file(a.path, json.dumps(a_dict))
+
+    with pytest.raises(
+        ValueError, match=r"Invalid content in resource file[\s\S]*input_value=0"
+    ):
+        a.load(force=True)


### PR DESCRIPTION
Contributes to #6

This is broken out of #9. It adds the first resource manager and perhaps the last if more types than json modeled by Pydantic are not needed.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
