### PR TITLE
ENH: Raise error if .fmu is not directory

### DIFF
--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -20,6 +20,7 @@ class FMUDirectory:
                        dirs
 
         Raises:
+            FileExistsError: If .fmu exists but is not a directory
             FileNotFoundError: If .fmu directory doesn't exist
             PermissionError: If lacking permissions to read/write to the directory
         """
@@ -27,8 +28,13 @@ class FMUDirectory:
         logger.debug(f"Initializing FMUDirectory from '{base_path}'")
 
         fmu_dir = self.base_path / ".fmu"
-        if fmu_dir.exists() and fmu_dir.is_dir():
-            self._path = fmu_dir
+        if fmu_dir.exists():
+            if fmu_dir.is_dir():
+                self._path = fmu_dir
+            else:
+                raise FileExistsError(
+                    f".fmu exists at {self.base_path} but is not a directory"
+                )
         else:
             raise FileNotFoundError(f"No .fmu directory found at {self.base_path}")
 
@@ -252,6 +258,7 @@ def get_fmu_directory(base_path: str | Path) -> FMUDirectory:
         FMUDirectory instance
 
     Raises:
+        FileExistsError: If .fmu exists but is not a directory
         FileNotFoundError: If .fmu directory doesn't exist
         PermissionError: If lacking permissions to read/write to the directory
 

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -58,6 +58,15 @@ def test_init_on_missing_directory(tmp_path: Path) -> None:
         FMUDirectory(tmp_path)
 
 
+def test_init_when_fmu_is_not_a_directory(tmp_path: Path) -> None:
+    """Tests initialized on a .fmu non-directory raises."""
+    (tmp_path / ".fmu").touch()
+    with pytest.raises(
+        FileExistsError, match=f".fmu exists at {tmp_path} but is not a directory"
+    ):
+        FMUDirectory(tmp_path)
+
+
 def test_find_fmu_directory(fmu_dir: FMUDirectory) -> None:
     """Tests find_fmu_directory method on nested children."""
     child = fmu_dir.base_path / "child"


### PR DESCRIPTION
Resolves #15

Gives a more specific error if .fmu exists but is not a directory.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
