### PR TITLE
ENH: Add 'masterdata' and 'smda' fields to config

### DIFF
--- a/src/fmu/settings/models/config.py
+++ b/src/fmu/settings/models/config.py
@@ -1,0 +1,30 @@
+"""The model for config.json."""
+
+from uuid import UUID  # noqa TC003
+
+from pydantic import AwareDatetime, BaseModel, Field
+
+from fmu.settings.types import VersionStr  # noqa TC001
+from .smda import Smda
+
+
+class Masterdata(BaseModel):
+    """The ``masterdata`` block contains information related to masterdata.
+
+    Currently, SMDA holds the masterdata.
+    """
+
+    smda: Smda | None = Field(default=None)
+    """Block containing SMDA-related attributes. See :class:`Smda`."""
+
+
+class Config(BaseModel):
+    """The configuration file in a .fmu directory.
+
+    Stored as config.json.
+    """
+
+    version: VersionStr
+    created_at: AwareDatetime
+    created_by: str
+    masterdata: Masterdata

--- a/src/fmu/settings/models/smda.py
+++ b/src/fmu/settings/models/smda.py
@@ -1,0 +1,90 @@
+"""Models for SMDA masterdata."""
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from fmu.settings.types import VersionStr  # noqa TC001
+
+
+class SmdaIdentifier(BaseModel):
+    """The identifier for something known to SMDA."""
+
+    identifier: str
+    """Identifier known to SMDA."""
+
+    uuid: UUID
+    """Identifier known to SMDA."""
+
+
+class CountryItem(SmdaIdentifier):
+    """A single country in the list of countries known to SMDA."""
+
+    identifier: str = Field(examples=["Norway"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class FieldItem(SmdaIdentifier):
+    """A single field in the list of fields known to SMDA."""
+
+    identifier: str = Field(examples=["OseFax"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class CoordinateSystem(SmdaIdentifier):
+    """Contains the coordinate system known to SMDA."""
+
+    identifier: str = Field(examples=["ST_WGS84_UTM37N_P32637"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class StratigraphicColumn(SmdaIdentifier):
+    """Contains the stratigraphic column known to SMDA."""
+
+    identifier: str = Field(examples=["DROGON_2020"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class DiscoveryItem(BaseModel):
+    """A single discovery in the list of discoveries known to SMDA."""
+
+    short_identifier: str = Field(examples=["SomeDiscovery"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class Smda(BaseModel):
+    """Contains SMDA-related attributes."""
+
+    coordinate_system: CoordinateSystem
+    """Reference to coordinate system known to SMDA.  See :class:`CoordinateSystem`."""
+
+    country: list[CountryItem]
+    """A list referring to countries known to SMDA. First item is primary.
+    See :class:`CountryItem`."""
+
+    discovery: list[DiscoveryItem]
+    """A list referring to discoveries known to SMDA. First item is primary.
+    See :class:`DiscoveryItem`."""
+
+    field: list[FieldItem]
+    """A list referring to fields known to SMDA. First item is primary.
+    See :class:`FieldItem`."""
+
+    stratigraphic_column: StratigraphicColumn
+    """Reference to stratigraphic column known to SMDA.
+    See :class:`StratigraphicColumn`."""

--- a/src/fmu/settings/resources/config.py
+++ b/src/fmu/settings/resources/config.py
@@ -6,11 +6,13 @@ import getpass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Self
+from uuid import UUID  # noqa TC003
 
-from pydantic import AwareDatetime, BaseModel, ValidationError
+from pydantic import ValidationError
 
 from fmu.settings import __version__
 from fmu.settings._logging import null_logger
+from fmu.settings.models.config import Config, Masterdata
 from fmu.settings.types import VersionStr  # noqa TC001
 
 from .managers import PydanticResourceManager
@@ -20,17 +22,6 @@ if TYPE_CHECKING:
     from fmu.settings._fmu_dir import FMUDirectory
 
 logger: Final = null_logger(__name__)
-
-
-class Config(BaseModel):
-    """The configuration file in a .fmu directory.
-
-    Stored as config.json.
-    """
-
-    version: VersionStr
-    created_at: AwareDatetime
-    created_by: str
 
 
 class ConfigManager(PydanticResourceManager[Config]):
@@ -199,6 +190,7 @@ class ConfigManager(PydanticResourceManager[Config]):
             version=__version__,
             created_at=datetime.now(UTC),
             created_by=getpass.getuser(),
+            masterdata=Masterdata(),
         )
 
         self.save(default_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from fmu.settings._fmu_dir import FMUDirectory
 from fmu.settings._init import init_fmu_directory
 from fmu.settings._version import __version__
-from fmu.settings.resources.config import Config
+from fmu.settings.models.config import Config
 
 
 @pytest.fixture
@@ -26,6 +26,57 @@ def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
         "version": __version__,
         "created_at": unix_epoch_utc,
         "created_by": "user",
+        "masterdata": {
+            "smda": None,
+        },
+    }
+
+
+@pytest.fixture
+def masterdata_dict() -> dict[str, Any]:
+    """Example masterdata from SMDA."""
+    return {
+        "smda": {
+            "country": [
+                {
+                    "identifier": "Norway",
+                    "uuid": "ad214d85-8a1d-19da-e053-c918a4889309",
+                }
+            ],
+            "discovery": [
+                {
+                    "short_identifier": "DROGON",
+                    "uuid": "ad214d85-8a1d-19da-e053-c918a4889309",
+                }
+            ],
+            "field": [
+                {
+                    "identifier": "DROGON",
+                    "uuid": "ad214d85-8a1d-19da-e053-c918a4889309",
+                }
+            ],
+            "coordinate_system": {
+                "identifier": "ST_WGS84_UTM37N_P32637",
+                "uuid": "ad214d85-dac7-19da-e053-c918a4889309",
+            },
+            "stratigraphic_column": {
+                "identifier": "DROGON_HAS_NO_STRATCOLUMN",
+                "uuid": "ad214d85-8a1d-19da-e053-c918a4889309",
+            },
+        }
+    }
+
+
+@pytest.fixture
+def config_dict_with_masterdata(
+    unix_epoch_utc: datetime, masterdata_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """A dictionary representing a .fmu config."""
+    return {
+        "version": __version__,
+        "created_at": unix_epoch_utc,
+        "created_by": "user",
+        "masterdata": masterdata_dict,
     }
 
 
@@ -33,6 +84,12 @@ def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
 def config_model(config_dict: dict[str, Any]) -> Config:
     """A Config model representing a .fmu config file."""
     return Config.model_validate(config_dict)
+
+
+@pytest.fixture
+def config_model_with_masterdata(config_dict_with_masterdata: dict[str, Any]) -> Config:
+    """A Config model representing a .fmu config file."""
+    return Config.model_validate(config_dict_with_masterdata)
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #18

Adds the non-optional `masterdata` block to the config with the nullable `masterdata.smda` field within it.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
