### PR TITLE
ENH: Add Model to ProjectConfig

### DIFF
--- a/src/fmu/settings/models/project_config.py
+++ b/src/fmu/settings/models/project_config.py
@@ -6,7 +6,7 @@ from typing import Self
 
 from pydantic import AwareDatetime, Field
 
-from fmu.datamodels.fmu_results.fields import Masterdata
+from fmu.datamodels.fmu_results.fields import Masterdata, Model
 from fmu.settings import __version__
 from fmu.settings.types import ResettableBaseModel, VersionStr  # noqa TC001
 
@@ -21,6 +21,7 @@ class ProjectConfig(ResettableBaseModel):
     created_at: AwareDatetime
     created_by: str
     masterdata: Masterdata | None = Field(default=None)
+    model: Model | None = Field(default=None)
 
     @classmethod
     def reset(cls: type[Self]) -> Self:
@@ -34,4 +35,5 @@ class ProjectConfig(ResettableBaseModel):
             created_at=datetime.now(UTC),
             created_by=getpass.getuser(),
             masterdata=None,
+            model=None,
         )

--- a/src/fmu/settings/resources/config_managers.py
+++ b/src/fmu/settings/resources/config_managers.py
@@ -73,7 +73,7 @@ class ConfigManager(PydanticResourceManager[T]):
             default: Value to return if key is not found. Default None
 
         Returns:
-            The configuration value or deafult
+            The configuration value or default
         """
         try:
             config = self.load()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
         "created_at": unix_epoch_utc,
         "created_by": "user",
         "masterdata": None,
+        "model": None,
     }
 
 
@@ -67,8 +68,20 @@ def masterdata_dict() -> dict[str, Any]:
 
 
 @pytest.fixture
+def model_dict() -> dict[str, Any]:
+    """Example model information."""
+    return {
+        "name": "Drogon",
+        "revision": "21.0.0",
+        "description": None,
+    }
+
+
+@pytest.fixture
 def config_dict_with_masterdata(
-    unix_epoch_utc: datetime, masterdata_dict: dict[str, Any]
+    unix_epoch_utc: datetime,
+    masterdata_dict: dict[str, Any],
+    model_dict: dict[str, Any],
 ) -> dict[str, Any]:
     """A dictionary representing a .fmu config."""
     return {
@@ -76,6 +89,7 @@ def config_dict_with_masterdata(
         "created_at": unix_epoch_utc,
         "created_by": "user",
         "masterdata": masterdata_dict,
+        "model": model_dict,
     }
 
 


### PR DESCRIPTION
Resolves #20 

PR to add the `model` block to the project config, using the `Model` model from fmu-datamodels.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
