### PR TITLE
ENH: Add Access to ProjectConfig

### DIFF
--- a/src/fmu/settings/models/project_config.py
+++ b/src/fmu/settings/models/project_config.py
@@ -6,7 +6,7 @@ from typing import Self
 
 from pydantic import AwareDatetime, Field
 
-from fmu.datamodels.fmu_results.fields import Masterdata, Model
+from fmu.datamodels.fmu_results.fields import Access, Masterdata, Model
 from fmu.settings import __version__
 from fmu.settings.types import ResettableBaseModel, VersionStr  # noqa TC001
 
@@ -22,6 +22,7 @@ class ProjectConfig(ResettableBaseModel):
     created_by: str
     masterdata: Masterdata | None = Field(default=None)
     model: Model | None = Field(default=None)
+    access: Access | None = Field(default=None)
 
     @classmethod
     def reset(cls: type[Self]) -> Self:
@@ -36,4 +37,5 @@ class ProjectConfig(ResettableBaseModel):
             created_by=getpass.getuser(),
             masterdata=None,
             model=None,
+            access=None,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
         "created_by": "user",
         "masterdata": None,
         "model": None,
+        "access": None,
     }
 
 
@@ -74,6 +75,15 @@ def model_dict() -> dict[str, Any]:
         "name": "Drogon",
         "revision": "21.0.0",
         "description": None,
+    }
+
+
+@pytest.fixture
+def access_dict() -> dict[str, Any]:
+    """Example access information."""
+    return {
+        "asset": {"name": "Drogon"},
+        "classification": "internal",
     }
 
 

--- a/tests/test_resources/test_project_config.py
+++ b/tests/test_resources/test_project_config.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from fmu.datamodels.fmu_results.fields import Model, Smda
+from fmu.datamodels.fmu_results.fields import Access, Model, Smda
 from fmu.settings._fmu_dir import ProjectFMUDirectory, UserFMUDirectory
 from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.models.user_config import UserConfig
@@ -289,6 +289,43 @@ def test_set_model(fmu_dir: ProjectFMUDirectory, model_dict: dict[str, Any]) -> 
     config_on_disk_model = ProjectConfig.model_validate(config_on_disk)
     assert fmu_dir.config._cache is not None
     assert fmu_dir.config._cache.model == model
+    assert config_on_disk_model == fmu_dir.config._cache
+
+
+def test_set_access_invalid_fails(
+    fmu_dir: ProjectFMUDirectory, access_dict: dict[str, Any]
+) -> None:
+    """Tests setting the access value in the config using an invalid dictionary."""
+    assert fmu_dir.config.get("access") is None
+
+    # drop access.asset to test validation
+    access_dict.pop("asset")
+
+    with pytest.raises(ValueError, match="access.asset"):
+        fmu_dir.set_config_value("access", access_dict)
+
+
+def test_set_access(fmu_dir: ProjectFMUDirectory, access_dict: dict[str, Any]) -> None:
+    """Tests setting the access value in the config."""
+    assert fmu_dir.config.get("access") is None
+    with open(fmu_dir.path / fmu_dir.config.relative_path, encoding="utf-8") as f:
+        config_on_disk = json.loads(f.read())
+    assert config_on_disk["access"] is None
+
+    fmu_dir.set_config_value("access", access_dict)
+
+    access = Access.model_validate(access_dict)
+
+    assert fmu_dir.get_config_value("access") == access
+    assert fmu_dir.get_config_value("access.classification") == "internal"
+    assert fmu_dir.get_config_value("access.asset.name") == "Drogon"
+
+    with open(fmu_dir.path / fmu_dir.config.relative_path, encoding="utf-8") as f:
+        config_on_disk = json.loads(f.read())
+
+    config_on_disk_model = ProjectConfig.model_validate(config_on_disk)
+    assert fmu_dir.config._cache is not None
+    assert fmu_dir.config._cache.access == access
     assert config_on_disk_model == fmu_dir.config._cache
 
 


### PR DESCRIPTION
Resolves #19 

PR to add the `access` block to the project config, using the `Access` model from `fmu-datamodels.`

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
