### PR TITLE
ENH: Clarify recent_directories as recent_project_directories

### DIFF
--- a/src/fmu/settings/models/user_config.py
+++ b/src/fmu/settings/models/user_config.py
@@ -13,7 +13,7 @@ from pydantic import AwareDatetime, BaseModel, SecretStr, field_serializer
 from fmu.settings import __version__
 from fmu.settings.types import ResettableBaseModel, VersionStr  # noqa TC001
 
-RecentDirectories = Annotated[set[Path], annotated_types.Len(0, 5)]
+RecentProjectDirectories = Annotated[set[Path], annotated_types.Len(0, 5)]
 
 
 class UserAPIKeys(BaseModel):
@@ -38,7 +38,7 @@ class UserConfig(ResettableBaseModel):
     version: VersionStr
     created_at: AwareDatetime
     user_api_keys: UserAPIKeys
-    recent_directories: RecentDirectories
+    recent_project_directories: RecentProjectDirectories
 
     @classmethod
     def reset(cls: type[Self]) -> Self:
@@ -47,7 +47,7 @@ class UserConfig(ResettableBaseModel):
             version=__version__,
             created_at=datetime.now(UTC),
             user_api_keys=UserAPIKeys(),
-            recent_directories=set(),
+            recent_project_directories=set(),
         )
 
     def obfuscate_secrets(self: Self) -> Self:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def user_config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
         "user_api_keys": {
             "smda_subscription": None,
         },
-        "recent_directories": [],
+        "recent_project_directories": [],
     }
 
 

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -288,30 +288,32 @@ def test_update_user_config(user_fmu_dir: UserFMUDirectory) -> None:
     """Tests update_config updates and saves the user config for multiple values."""
     recent_dir = "/foo/bar"
     updated_config = user_fmu_dir.update_config(
-        {"version": "2.0.0", "recent_directories": [recent_dir]}
+        {"version": "2.0.0", "recent_project_directories": [recent_dir]}
     )
 
     assert updated_config.version == "2.0.0"
-    assert updated_config.recent_directories == {Path(recent_dir)}
+    assert updated_config.recent_project_directories == {Path(recent_dir)}
 
     assert user_fmu_dir.config.load() is not None
     assert user_fmu_dir.get_config_value("version", None) == "2.0.0"
-    assert user_fmu_dir.get_config_value("recent_directories") == {Path(recent_dir)}
+    assert user_fmu_dir.get_config_value("recent_project_directories") == {
+        Path(recent_dir)
+    }
 
     config_file = user_fmu_dir.config.path
     with open(config_file, encoding="utf-8") as f:
         saved_config = json.load(f)
 
     assert saved_config["version"] == "2.0.0"
-    assert saved_config["recent_directories"] == [recent_dir]
+    assert saved_config["recent_project_directories"] == [recent_dir]
 
 
 def test_update_user_config_invalid_data(user_fmu_dir: UserFMUDirectory) -> None:
     """Tests that update_config raises ValidationError on bad data."""
-    updates = {"recent_directories": [123]}
+    updates = {"recent_project_directories": [123]}
     with pytest.raises(
         ValueError,
         match="Invalid value set for 'UserConfigManager' with updates "
-        "'{'recent_directories':",
+        "'{'recent_project_directories':",
     ):
         user_fmu_dir.update_config(updates)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -134,7 +134,7 @@ def test_init_user_fmu_directory(
     assert config_json["version"] == __version__
     assert config_json["created_at"] != str(unix_epoch_utc)
     assert config_json["user_api_keys"] == {"smda_subscription": None}
-    assert config_json["recent_directories"] == []
+    assert config_json["recent_project_directories"] == []
 
     created_at = datetime.fromisoformat(config_json["created_at"])
     now = datetime.now(UTC)


### PR DESCRIPTION
Resolves #29 

PR to clarify that `recent_directories` in the `UserConfig` referrers to project directories by renaming it to `recent_project_directories` .

## Checklist

- [x] Existing tests sufficient
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
