### PR TITLE
ENH: Change recent_project_directories to list type

### DIFF
--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -292,13 +292,13 @@ def test_update_user_config(user_fmu_dir: UserFMUDirectory) -> None:
     )
 
     assert updated_config.version == "2.0.0"
-    assert updated_config.recent_project_directories == {Path(recent_dir)}
+    assert updated_config.recent_project_directories == [Path(recent_dir)]
 
     assert user_fmu_dir.config.load() is not None
     assert user_fmu_dir.get_config_value("version", None) == "2.0.0"
-    assert user_fmu_dir.get_config_value("recent_project_directories") == {
+    assert user_fmu_dir.get_config_value("recent_project_directories") == [
         Path(recent_dir)
-    }
+    ]
 
     config_file = user_fmu_dir.config.path
     with open(config_file, encoding="utf-8") as f:
@@ -316,4 +316,13 @@ def test_update_user_config_invalid_data(user_fmu_dir: UserFMUDirectory) -> None
         match="Invalid value set for 'UserConfigManager' with updates "
         "'{'recent_project_directories':",
     ):
+        user_fmu_dir.update_config(updates)
+
+
+def test_update_user_config_non_unique_recent_projects(
+    user_fmu_dir: UserFMUDirectory,
+) -> None:
+    """Tests that update_config raises on non-unique recent_project_directories."""
+    updates = {"recent_project_directories": [Path("/foo/bar"), Path("/foo/bar")]}
+    with pytest.raises(ValueError, match="unique entries"):
         user_fmu_dir.update_config(updates)


### PR DESCRIPTION
Resolves #52 

PR to change `recent_project_directories` from a `set` to a `list`.
A field_validator is added to check that the elements in the input list is unique.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
