### PR TITLE
ENH: Allow importing global config or variables on init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "PyYAML",
     "annotated_types",  # Dependency in Pydantic also
+    "fmu-config",
     "fmu-datamodels",
     "pydantic",
 ]
@@ -41,6 +43,7 @@ dev = [
     "pytest-mock",
     "pytest-xdist",
     "ruff",
+    "types-PyYAML",
 ]
 
 [project.urls]

--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -82,7 +82,9 @@ class FMUDirectoryBase:
             FileNotFoundError: If config file doesn't exist
             ValueError: If the updated config is invalid
         """
+        logger.info(f"Setting {key} in {self.path}")
         self.config.set(key, value)
+        logger.debug(f"Set {key} to {value}")
 
     def update_config(
         self: Self, updates: dict[str, Any]

--- a/src/fmu/settings/_global_config.py
+++ b/src/fmu/settings/_global_config.py
@@ -1,0 +1,241 @@
+"""Functions related to finding and validating an existing global configuration."""
+
+from pathlib import Path
+from typing import Final
+
+from fmu.config.utilities import yaml_load
+from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
+
+from ._logging import null_logger
+
+logger: Final = null_logger(__name__)
+
+# These should all be normalized to lower case.
+INVALID_NAMES: Final[tuple[str, ...]] = (
+    "drogon",
+    "drogon_2020",
+    "drogon_has_no_stratcolumn",
+)
+INVALID_UUIDS: Final[tuple[str, ...]] = (
+    "ad214d85-dac7-19da-e053-c918a4889309",
+    "ad214d85-8a1d-19da-e053-c918a4889310",
+    "00000000-0000-0000-0000-000000000000",
+)
+INVALID_STRAT_NAMES: Final[tuple[str, ...]] = (
+    "basevolantis",
+    "basetherys",
+    "basevalysar",
+    "basevolon",
+    "therys",
+    "toptherys",
+    "topvolantis",
+    "topvolon",
+    "topvalysar",
+    "valysar",
+    "volantis",
+    "volon",
+)
+
+
+def validate_global_configuration_strictly(cfg: GlobalConfiguration) -> None:  # noqa: PLR0912
+    """Does stricter checks against a valid GlobalConfiguration file.
+
+    This is to prevent importing existing but incorrect data that should not make it
+    into a project .fmu configuration. An example of this is Drogon masterdata.
+
+    Args:
+        cfg: A GlobalConfiguration instance to be validated
+
+    Raises:
+        ValueError: If some value in the GlobalConfiguration is invalid or not allowed
+    """
+    # Check model and access
+    if cfg.model.name.lower() in INVALID_NAMES:
+        raise ValueError(f"Invalid name in 'model': {cfg.model.name}")
+    if cfg.access.asset.name.lower() in INVALID_NAMES:
+        raise ValueError(f"Invalid name in 'access.asset': {cfg.access.asset.name}")
+
+    # Check masterdata
+
+    # smda.country
+    for country in cfg.masterdata.smda.country:
+        if str(country.uuid) in INVALID_UUIDS:
+            raise ValueError(f"Invalid SMDA UUID in 'smda.country': {country.uuid}")
+
+    # smda.discovery
+    for discovery in cfg.masterdata.smda.discovery:
+        if discovery.short_identifier.lower() in INVALID_NAMES:
+            raise ValueError(
+                f"Invalid SMDA short identifier in 'smda.discovery': "
+                f"{discovery.short_identifier}"
+            )
+        if str(discovery.uuid) in INVALID_UUIDS:
+            raise ValueError(f"Invalid SMDA UUID in 'smda.discovery': {discovery.uuid}")
+
+    # smda.field
+    for field in cfg.masterdata.smda.field:
+        if field.identifier.lower() in INVALID_NAMES:
+            raise ValueError(
+                f"Invalid SMDA identifier in 'smda.field': {field.identifier}"
+            )
+        if str(field.uuid) in INVALID_UUIDS:
+            raise ValueError(f"Invalid SMDA UUID in 'smda.field': {field.uuid}")
+
+    # smda.coordinate_system
+    if (coord_uuid := str(cfg.masterdata.smda.coordinate_system.uuid)) in INVALID_UUIDS:
+        raise ValueError(f"Invalid SMDA UUID in 'smda.coordinate_system': {coord_uuid}")
+
+    # smda.stratigraphic_column
+    strat = cfg.masterdata.smda.stratigraphic_column
+    if strat.identifier.lower() in INVALID_NAMES:
+        raise ValueError(
+            f"Invalid SMDA identifier in 'smda.stratigraphic_column': "
+            f"{strat.identifier}"
+        )
+    if str(strat.uuid) in INVALID_UUIDS:
+        raise ValueError(
+            f"Invalid SMDA UUID in 'smda.stratigraphic_column': {strat.uuid}"
+        )
+
+    # Check stratigraphy
+
+    if cfg.stratigraphy:
+        for key in cfg.stratigraphy:
+            if key.lower() in INVALID_STRAT_NAMES:
+                raise ValueError(
+                    f"Invalid stratigraphy name in 'smda.stratigraphy': {key}"
+                )
+
+
+def load_global_configuration_if_present(
+    path: Path, fmu_load: bool = False
+) -> GlobalConfiguration | None:
+    """Loads a global config/global variables at a path.
+
+    This loads via fmu-config, which is capable of loading a global _config_, which is
+    different from the global _variables_ in that it may still be in separate files
+    linked by the custom '!include' directive.
+
+    Args:
+        path: The path to the yaml file
+        fmu_load: Whether or not to load in the custom 'fmu' format. Default False.
+
+    Returns:
+        GlobalConfiguration instance or None.
+    """
+    loader = "fmu" if fmu_load else "standard"
+    try:
+        global_variables_dict = yaml_load(path, loader=loader)
+        global_config = GlobalConfiguration.model_validate(global_variables_dict)
+        logger.debug(f"Global variables at {path} has valid settings data")
+    except Exception:
+        logger.debug(f"Global variables at {path} does not have valid settings data")
+        return None
+    return global_config
+
+
+def _find_global_variables_file(paths: list[Path]) -> GlobalConfiguration | None:
+    """Finds a valid global variables file, or not.
+
+    This is the _output_ file after fmuconfig is run.
+
+    Args:
+        paths: A list of Paths to check.
+
+    Returns:
+        A validated GlobalConfiguration or None.
+    """
+    for path in paths:
+        if not path.exists():
+            continue
+
+        global_variables_path = path
+        # If the path is a dir, and doesn't contain the right file, move on.
+        if path.is_dir():
+            global_variables_path = path / "global_variables.yml"
+            if not global_variables_path.exists():
+                continue
+
+        logger.info(f"Found global variables at {path}")
+        global_config = load_global_configuration_if_present(global_variables_path)
+        if not global_config:
+            continue
+        return global_config
+
+    return None
+
+
+def _find_global_config_file(paths: list[Path]) -> GlobalConfiguration | None:
+    """Finds a valid global configuration file, or not.
+
+    This is the _input_ file, before fmuconfig is run.
+
+    Args:
+        paths: A list of Paths to check.
+
+    Returns:
+        A validated GlobalConfiguration or None.
+    """
+    for path in paths:
+        if not path.exists():
+            continue
+
+        logger.info(f"Found global config at {path}")
+        # May be global_config*.yml or global_master*.yml
+        for global_config_path in path.glob("**/global*.yml"):
+            global_config = load_global_configuration_if_present(
+                global_config_path, fmu_load=True
+            )
+            if not global_config:
+                continue
+            return global_config
+
+    return None
+
+
+def find_global_config(
+    base_path: str | Path,
+    extra_output_paths: list[Path] | None = None,
+    extra_input_dirs: list[Path] | None = None,
+    strict: bool = True,
+) -> GlobalConfiguration | None:
+    """Try to locate a global configuration with valid masterdata in known location.
+
+    Extra paths may be provided
+
+    Args:
+        base_path: The path to the project root
+        extra_output_paths: A list of extra paths to a global _variables_.
+        extra_input_dirs: A list of extra dirs to a global _config_ might be.
+        strict: If True, valid data but invalid _content_ is disallowed, i.e.  Drogon
+            data. Default True.
+
+    Returns:
+        A valid GlobalConfiguration instance, or None.
+    """
+    base_path = Path(base_path)
+
+    # Loads with 'fmu_load=False'
+    known_output_paths = [base_path / "fmuconfig/output/global_variables.yml"]
+    if extra_output_paths:
+        known_output_paths += extra_output_paths
+
+    global_config = _find_global_variables_file(known_output_paths)
+    if global_config:
+        if strict:
+            validate_global_configuration_strictly(global_config)
+        return global_config
+
+    # Loads with 'fmu_load=True'
+    known_input_paths = [base_path / "fmuconfig/input"]
+    if extra_input_dirs:
+        known_input_paths += extra_input_dirs
+
+    global_config = _find_global_config_file(known_input_paths)
+    if global_config:
+        if strict:
+            validate_global_configuration_strictly(global_config)
+        return global_config
+
+    logger.info("No global variables or config with valid settings data found.")
+    return None

--- a/src/fmu/settings/_init.py
+++ b/src/fmu/settings/_init.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Final
 
+from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
+
 from ._fmu_dir import ProjectFMUDirectory, UserFMUDirectory
 from ._logging import null_logger
 from .models.project_config import ProjectConfig
@@ -66,7 +68,9 @@ def _create_fmu_directory(base_path: Path) -> None:
 
 
 def init_fmu_directory(
-    base_path: str | Path, config_data: ProjectConfig | dict[str, Any] | None = None
+    base_path: str | Path,
+    config_data: ProjectConfig | dict[str, Any] | None = None,
+    global_config: GlobalConfiguration | None = None,
 ) -> ProjectFMUDirectory:
     """Creates and initializes a .fmu directory.
 
@@ -74,9 +78,11 @@ def init_fmu_directory(
     function.
 
     Args:
-        base_path: Directory where .fmu should be created
+        base_path: Directory where .fmu should be created.
         config_data: Optional ProjectConfig instance or dictionary with configuration
-          data
+          data.
+        global_config: Optional GlobaConfiguration instance with existing global config
+          data.
 
     Returns:
         Instance of FMUDirectory
@@ -98,12 +104,14 @@ def init_fmu_directory(
     fmu_dir.config.reset()
     if config_data:
         if isinstance(config_data, ProjectConfig):
-            config_dict = config_data.model_dump()
-            fmu_dir.update_config(config_dict)
-        elif isinstance(config_data, dict):
-            fmu_dir.update_config(config_data)
+            config_data = config_data.model_dump()
+        fmu_dir.update_config(config_data)
 
-    logger.debug(f"Successfully initialized .fmu directory at '{fmu_dir}'")
+    if global_config:
+        for key, value in global_config.model_dump().items():
+            fmu_dir.set_config_value(key, value)
+
+    logger.info(f"Successfully initialized .fmu directory at '{fmu_dir}'")
     return fmu_dir
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,23 @@
 """Root configuration for pytest."""
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
+import yaml
+from fmu.datamodels.fmu_results import fields
+from fmu.datamodels.fmu_results.enums import Classification
+from fmu.datamodels.fmu_results.global_configuration import (
+    Access,
+    GlobalConfiguration,
+    Stratigraphy,
+    StratigraphyElement,
+)
+from pytest import MonkeyPatch
 
 from fmu.settings._fmu_dir import ProjectFMUDirectory, UserFMUDirectory
 from fmu.settings._init import init_fmu_directory, init_user_fmu_directory
@@ -85,6 +97,179 @@ def access_dict() -> dict[str, Any]:
         "asset": {"name": "Drogon"},
         "classification": "internal",
     }
+
+
+@pytest.fixture
+def stratigraphy_dict() -> dict[str, Any]:
+    """Example stratigraphy information."""
+    return {
+        "MSL": {
+            "stratigraphic": False,
+            "name": "MSL",
+        },
+        "Seabase": {
+            "stratigraphic": False,
+            "name": "Seabase",
+        },
+        "TopVolantis": {
+            "stratigraphic": True,
+            "name": "VOLANTIS GP. Top",
+            "alias": ["TopVOLANTIS", "TOP_VOLANTIS"],
+            "stratigraphic_alias": ["TopValysar", "Valysar Fm. Top"],
+        },
+        "TopTherys": {"stratigraphic": True, "name": "Therys Fm. Top"},
+        "TopVolon": {"stratigraphic": True, "name": "Volon Fm. Top"},
+        "BaseVolon": {"stratigraphic": True, "name": "Volon Fm. Base"},
+        "BaseVolantis": {"stratigraphic": True, "name": "VOLANTIS GP. Base"},
+        "Mantle": {"stratigraphic": False, "name": "Mantle"},
+        "Above": {"stratigraphic": False, "name": "Above"},
+        "Valysar": {"stratigraphic": True, "name": "Valysar Fm."},
+        "Therys": {"stratigraphic": True, "name": "Therys Fm."},
+        "Volon": {"stratigraphic": True, "name": "Volon Fm."},
+        "Below": {"stratigraphic": False, "name": "Below"},
+    }
+
+
+@pytest.fixture
+def global_variables_without_masterdata() -> dict[str, Any]:
+    """Example global_variables.yml file without masterdata."""
+    return {
+        "global": {
+            "dates": ["2018-01-01", "2018-07-01", "2019-07-01", "2020-07-01"],
+        },
+    }
+
+
+@pytest.fixture
+def global_variables_with_masterdata(
+    masterdata_dict: dict[str, Any],
+    access_dict: dict[str, Any],
+    model_dict: dict[str, Any],
+    stratigraphy_dict: dict[str, Any],
+    global_variables_without_masterdata: dict[str, Any],
+) -> dict[str, Any]:
+    """Example global_variables.yml file with masterdata."""
+    return {
+        "masterdata": masterdata_dict,
+        "access": access_dict,
+        "model": model_dict,
+        "stratigraphy": stratigraphy_dict,
+        **global_variables_without_masterdata,
+    }
+
+
+@pytest.fixture
+def fmuconfig_with_input(  # noqa: PLR0913 too many args
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    masterdata_dict: dict[str, Any],
+    access_dict: dict[str, Any],
+    model_dict: dict[str, Any],
+    stratigraphy_dict: dict[str, Any],
+    global_variables_without_masterdata: dict[str, Any],
+) -> Path:
+    """Creates an fmuconfig/ path and input directory.
+
+    Returns:
+        tmp_path.
+    """
+    fmuconfig_input = tmp_path / "fmuconfig/input"
+    fmuconfig_input.mkdir(parents=True, exist_ok=True)
+
+    with open(fmuconfig_input / "_masterdata.yml", "w") as f:
+        yaml.safe_dump(masterdata_dict, f)
+    with open(fmuconfig_input / "_access.yml", "w") as f:
+        yaml.safe_dump(access_dict, f)
+    with open(fmuconfig_input / "_stratigraphy.yml", "w") as f:
+        yaml.safe_dump(stratigraphy_dict, f)
+
+    global_config_dict = {
+        **global_variables_without_masterdata,
+        "model": model_dict,
+        "masterdata": "!include _masterdata.yml",
+        "access": "!include _access.yml",
+        "stratigraphy": "!include _stratigraphy.yml",
+    }
+    # Remove quotes around strings. PyYAML quotes string beginning with ! by default as
+    # they indicate a yaml tag, for which fmu-config has defined one in this case.
+    global_config_yml = yaml.dump(
+        global_config_dict, default_style=None, default_flow_style=False
+    ).replace("'", "")
+
+    with open(fmuconfig_input / "global_master_config.yml", "w") as f:
+        f.write(global_config_yml)
+
+    return tmp_path
+
+
+@pytest.fixture
+def fmuconfig_with_output(  # noqa: PLR0913 too many args
+    fmuconfig_with_input: Path,
+    global_variables_with_masterdata: dict[str, Any],
+) -> Path:
+    """Creates an fmuconfig/ path and input/output directory.
+
+    Returns:
+        tmp_path
+    """
+    fmuconfig_output = fmuconfig_with_input / "fmuconfig/output"
+    fmuconfig_output.mkdir(parents=True, exist_ok=True)
+
+    with open(fmuconfig_output / "global_variables.yml", "w") as f:
+        yaml.safe_dump(
+            global_variables_with_masterdata,
+            f,
+            default_style=None,
+            default_flow_style=False,
+        )
+
+    return fmuconfig_with_input
+
+
+@pytest.fixture
+def generate_strict_valid_globalconfiguration() -> Callable[[], GlobalConfiguration]:
+    """Generates a global configuration that is valid, but can switch particular models.
+
+    All values are left empty by default.
+    """
+
+    def _generate_cfg(  # noqa: PLR0913
+        *,
+        classification: Classification | None = Classification.internal,
+        asset: fields.Asset | None = None,
+        coordinate_system: fields.CoordinateSystem | None = None,
+        stratigraphic_column: fields.StratigraphicColumn | None = None,
+        country_items: list[fields.CountryItem] | None = None,
+        discovery_items: list[fields.DiscoveryItem] | None = None,
+        field_items: list[fields.FieldItem] | None = None,
+        model: fields.Model | None = None,
+    ) -> GlobalConfiguration:
+        return GlobalConfiguration(
+            access=Access(
+                asset=asset or fields.Asset(name=""), classification=classification
+            ),
+            masterdata=fields.Masterdata(
+                smda=fields.Smda(
+                    coordinate_system=(
+                        coordinate_system
+                        or fields.CoordinateSystem(identifier="", uuid=uuid4())
+                    ),
+                    stratigraphic_column=(
+                        stratigraphic_column
+                        or fields.StratigraphicColumn(identifier="", uuid=uuid4())
+                    ),
+                    country=country_items or [],
+                    discovery=discovery_items or [],
+                    field=field_items or [],
+                )
+            ),
+            model=model or fields.Model(name="", revision=""),
+            stratigraphy=Stratigraphy(
+                {"MSL": StratigraphyElement(name="MSL", stratigraphic=False)}
+            ),
+        )
+
+    return _generate_cfg
 
 
 @pytest.fixture

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -1,0 +1,470 @@
+"""Tests for fmu.settings._global_config."""
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+import yaml
+from fmu.datamodels.fmu_results import fields
+from fmu.datamodels.fmu_results.global_configuration import (
+    GlobalConfiguration,
+    StratigraphyElement,
+)
+
+from fmu.settings._global_config import (
+    _find_global_config_file,
+    _find_global_variables_file,
+    find_global_config,
+    load_global_configuration_if_present,
+    validate_global_configuration_strictly,
+)
+
+STRICT_VALIDATION_IDENTIFIERS: list[tuple[str, bool]] = [
+    ("Drogon", False),  # False = not valid, True = valid
+    ("DROGON", False),
+    ("drogon_2020", False),
+    ("Dragon", True),
+    ("TROLL", True),
+]
+
+STRICT_VALIDATION_UUIDS: list[tuple[UUID, bool]] = [
+    (UUID("ad214d85-dac7-19da-e053-c918a4889309"), False),
+    (UUID("ad214d85-8a1d-19da-e053-c918a4889310"), False),
+    (UUID("00000000-0000-0000-0000-000000000000"), False),
+    (uuid4(), True),
+]
+
+STRICT_VALIDATION_STRAT_COLS: list[tuple[str, bool]] = [
+    ("TopVolantis", False),
+    ("Valysar", False),
+    ("Viking", True),
+]
+
+
+# Test validation of invalid content/values.
+
+
+@pytest.mark.parametrize("name, valid", STRICT_VALIDATION_IDENTIFIERS)
+def test_validate_global_config_strict_model(
+    name: str,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'model'."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        model=fields.Model(name=name, revision=""),
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(ValueError, match=f"Invalid name in 'model': {name}"):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("name, valid", STRICT_VALIDATION_IDENTIFIERS)
+def test_validate_global_config_strict_access(
+    name: str,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'access'."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        asset=fields.Asset(name=name),
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(ValueError, match=f"Invalid name in 'access.asset': {name}"):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("uuid, valid", STRICT_VALIDATION_UUIDS)
+def test_validate_global_config_strict_smda_country_uuid(
+    uuid: UUID,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.country' uuids."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        country_items=[
+            fields.CountryItem(identifier="bar", uuid=uuid),
+            fields.CountryItem(identifier="foo", uuid=uuid4()),
+        ],
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError, match=f"Invalid SMDA UUID in 'smda.country': {uuid}"
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("identifier, valid", STRICT_VALIDATION_IDENTIFIERS)
+def test_validate_global_config_strict_smda_discovery_identifier(
+    identifier: str,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.discovery' identifiers."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        discovery_items=[
+            fields.DiscoveryItem(short_identifier=identifier, uuid=uuid4()),
+            fields.DiscoveryItem(short_identifier="foo", uuid=uuid4()),
+        ],
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid SMDA short identifier in 'smda.discovery': {identifier}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("uuid, valid", STRICT_VALIDATION_UUIDS)
+def test_validate_global_config_strict_smda_discovery_uuid(
+    uuid: UUID,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.discovery' uuids."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        discovery_items=[
+            fields.DiscoveryItem(short_identifier="bar", uuid=uuid),
+            fields.DiscoveryItem(short_identifier="foo", uuid=uuid4()),
+        ],
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid SMDA UUID in 'smda.discovery': {uuid}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("identifier, valid", STRICT_VALIDATION_IDENTIFIERS)
+def test_validate_global_config_strict_smda_field_identifier(
+    identifier: str,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.discovery' identifiers."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        field_items=[
+            fields.FieldItem(identifier=identifier, uuid=uuid4()),
+            fields.FieldItem(identifier="foo", uuid=uuid4()),
+        ],
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid SMDA identifier in 'smda.field': {identifier}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("uuid, valid", STRICT_VALIDATION_UUIDS)
+def test_validate_global_config_strict_smda_field_uuid(
+    uuid: UUID,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.discovery' uuids."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        field_items=[
+            fields.FieldItem(identifier="bar", uuid=uuid),
+            fields.FieldItem(identifier="foo", uuid=uuid4()),
+        ],
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid SMDA UUID in 'smda.field': {uuid}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("uuid, valid", STRICT_VALIDATION_UUIDS)
+def test_validate_global_config_strict_coordinate_system(
+    uuid: UUID,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.coordinate_system'."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        coordinate_system=fields.CoordinateSystem(identifier="", uuid=uuid),
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError, match=f"Invalid SMDA UUID in 'smda.coordinate_system': {uuid}"
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("uuid, valid", STRICT_VALIDATION_UUIDS)
+def test_validate_global_config_strict_stratigraphic_column_uuids(
+    uuid: UUID,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.stratigraphic_column' uuid."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        stratigraphic_column=fields.StratigraphicColumn(identifier="", uuid=uuid),
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid SMDA UUID in 'smda.stratigraphic_column': {uuid}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("identifier, valid", STRICT_VALIDATION_IDENTIFIERS)
+def test_validate_global_config_strict_stratigraphic_column_names(
+    identifier: str,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.stratigraphic_column' identifiers."""
+    cfg = generate_strict_valid_globalconfiguration(  # type: ignore
+        stratigraphic_column=fields.StratigraphicColumn(
+            identifier=identifier, uuid=uuid4()
+        ),
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid SMDA identifier in 'smda.stratigraphic_column': "
+            f"{identifier}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+@pytest.mark.parametrize("identifier, valid", STRICT_VALIDATION_STRAT_COLS)
+def test_validate_global_config_strict_stratigraphy_names(
+    identifier: str,
+    valid: bool,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> None:
+    """Tests strict validation on 'smda.stratigraphic_column' identifiers."""
+    cfg = generate_strict_valid_globalconfiguration()
+    assert cfg.stratigraphy
+    cfg.stratigraphy.root[identifier] = StratigraphyElement(
+        name=identifier, stratigraphic=False
+    )
+    if valid:
+        validate_global_configuration_strictly(cfg)  # Does not raise
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid stratigraphy name in 'smda.stratigraphy': {identifier}",
+        ):
+            validate_global_configuration_strictly(cfg)
+
+
+# Test load_global_configuration_if_present
+
+
+@pytest.mark.parametrize("fmu_load", [True, False])
+def test_load_global_configuration_returns_none_if_invalid_yaml(
+    fmu_load: bool, tmp_path: Path
+) -> None:
+    """Tests maybe_load returns None if an Exception is raised."""
+    config_path = tmp_path / "global_config.yml"
+    with open(config_path, "w") as f:
+        f.write("foo=bar")
+
+    assert load_global_configuration_if_present(config_path, fmu_load=fmu_load) is None
+
+
+@pytest.mark.parametrize("fmu_load", [True, False])
+def test_load_global_configuration_returns_none_if_invalid_config(
+    fmu_load: bool,
+    tmp_path: Path,
+    global_variables_with_masterdata: dict[str, Any],
+) -> None:
+    """Tests maybe_load returns None if an Exception is raised."""
+    config_path = tmp_path / "global_config.yml"
+    del global_variables_with_masterdata["masterdata"]
+    with open(config_path, "w") as f:
+        yaml.safe_dump(global_variables_with_masterdata, f)
+
+    assert load_global_configuration_if_present(config_path, fmu_load=fmu_load) is None
+
+
+# Test finding global variables
+
+
+def test_find_global_config_file_not_there(tmp_path: Path) -> None:
+    """Tests finding the global config file if it is not present."""
+    assert _find_global_config_file([]) is None
+    assert _find_global_config_file([tmp_path]) is None
+    assert _find_global_config_file([tmp_path / "dne"]) is None
+
+
+def test_find_global_configs_file_malformed(tmp_path: Path) -> None:
+    """Tests finding the global config file if it is malformed."""
+    with open(tmp_path / "global_master_config.yml", "w") as f:
+        f.write("foo: bar")
+    assert _find_global_config_file([tmp_path]) is None
+
+
+def test_find_global_config_file(fmuconfig_with_output: Path) -> None:
+    """Tests finding the global variables file in fmuconfig."""
+    tmp_path = fmuconfig_with_output
+    some_dir = tmp_path / "some_dir"
+    some_dir.mkdir()
+    some_file = some_dir / "some_file"
+    some_file.touch()
+    does_not_exist = tmp_path / "bad"
+    assert _find_global_config_file([does_not_exist, some_dir, some_file]) is None
+
+    fmuconfig_input = fmuconfig_with_output / "fmuconfig/input"
+    global_variables = fmuconfig_input / "global_master_config.yml"
+    shutil.copy(global_variables, fmuconfig_input / "global_master_config_pred.yml")
+
+    assert isinstance(
+        _find_global_config_file(
+            [does_not_exist, some_dir, some_file, fmuconfig_input]
+        ),
+        GlobalConfiguration,
+    )
+
+
+def test_find_global_variables_file_not_there(tmp_path: Path) -> None:
+    """Tests finding the global variables file if it is not present."""
+    assert _find_global_variables_file([]) is None
+    assert _find_global_variables_file([tmp_path]) is None
+    assert _find_global_variables_file([tmp_path / "dne"]) is None
+
+
+def test_find_global_variables_file_malformed(tmp_path: Path) -> None:
+    """Tests finding the global variables file if it is malformed."""
+    with open(tmp_path / "global_variables.yml", "w") as f:
+        f.write("foo: bar")
+    assert _find_global_variables_file([tmp_path]) is None
+
+
+def test_find_global_variables_file(fmuconfig_with_output: Path) -> None:
+    """Tests finding the global variables file in fmuconfig."""
+    tmp_path = fmuconfig_with_output
+    some_dir = tmp_path / "some_dir"
+    some_dir.mkdir()
+    some_file = some_dir / "some_file"
+    some_file.touch()
+    does_not_exist = tmp_path / "bad"
+    assert _find_global_variables_file([does_not_exist, some_dir, some_file]) is None
+
+    assert isinstance(
+        _find_global_variables_file(
+            [
+                does_not_exist,
+                some_dir,
+                some_file,
+                fmuconfig_with_output / "fmuconfig/output",
+            ]
+        ),
+        GlobalConfiguration,
+    )
+
+
+def test_find_global_config_does_not_exist(tmp_path: Path) -> None:
+    """Tests that find_global_config returns None if no config exists."""
+    assert find_global_config(tmp_path) is None
+    assert find_global_config(tmp_path, strict=False) is None
+
+
+def test_find_global_config_from_input_non_strict(
+    fmuconfig_with_input: Path,
+) -> None:
+    """Tests finding a global config from the input dir."""
+    tmp_path = fmuconfig_with_input
+    cfg = find_global_config(tmp_path, strict=False)
+    assert isinstance(cfg, GlobalConfiguration)
+
+    # Validate all fields present
+    assert cfg.access.asset.name == "Drogon"
+    assert cfg.access.classification == "internal"
+    assert cfg.masterdata.smda.country[0].identifier == "Norway"
+    assert cfg.masterdata.smda.discovery[0].short_identifier == "DROGON"
+    assert cfg.masterdata.smda.field[0].identifier == "DROGON"
+    assert cfg.masterdata.smda.coordinate_system.identifier == "ST_WGS84_UTM37N_P32637"
+    assert (
+        cfg.masterdata.smda.stratigraphic_column.identifier
+        == "DROGON_HAS_NO_STRATCOLUMN"
+    )
+    assert cfg.model.name == "Drogon"
+    assert cfg.stratigraphy is not None
+    assert cfg.stratigraphy["TopVolantis"].name == "VOLANTIS GP. Top"
+
+
+def test_find_global_config_from_input_strict(
+    fmuconfig_with_input: Path,
+) -> None:
+    """Tests finding a global config with 'Drogon' in it raises."""
+    tmp_path = fmuconfig_with_input
+    with pytest.raises(ValueError, match="Invalid name in 'model': Drogon"):
+        find_global_config(tmp_path)
+
+
+def test_find_global_config_extra_output_paths(
+    fmuconfig_with_output: Path,
+) -> None:
+    """Tests finding global variables with extra output paths."""
+    tmp_path = fmuconfig_with_output
+    base_path = tmp_path / "some_dir"
+    base_path.mkdir()
+
+    cfg = find_global_config(
+        base_path,
+        extra_output_paths=[tmp_path / "fmuconfig/output/global_variables.yml"],
+        strict=False,
+    )
+    assert isinstance(cfg, GlobalConfiguration)
+
+    with pytest.raises(ValueError, match="Invalid name in 'model': Drogon"):
+        find_global_config(
+            base_path,
+            extra_output_paths=[tmp_path / "fmuconfig/output/global_variables.yml"],
+        )
+    assert isinstance(cfg, GlobalConfiguration)
+
+
+def test_find_global_config_extra_input_paths(
+    fmuconfig_with_input: Path,
+) -> None:
+    """Tests finding global variables with extra input paths."""
+    tmp_path = fmuconfig_with_input
+    base_path = tmp_path / "some_dir"
+    base_path.mkdir()
+
+    cfg = find_global_config(
+        base_path,
+        extra_input_dirs=[tmp_path / "fmuconfig/input"],
+        strict=False,
+    )
+    assert isinstance(cfg, GlobalConfiguration)
+
+    with pytest.raises(ValueError, match="Invalid name in 'model': Drogon"):
+        find_global_config(
+            base_path,
+            extra_input_dirs=[tmp_path / "fmuconfig/input"],
+        )
+    assert isinstance(cfg, GlobalConfiguration)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from fmu.settings import __version__
+from fmu.settings._global_config import find_global_config
 from fmu.settings._init import (
     _README,
     _USER_README,
@@ -102,6 +103,23 @@ def test_write_fmu_config_roundtrip(tmp_path: Path) -> None:
         config_data = json.loads(f.read())
     # Fails if invalid
     ProjectConfig.model_validate(config_data)
+
+
+def test_write_fmu_config_with_global_config(fmuconfig_with_output: Path) -> None:
+    """Tests creating an .fmu config with a global_config."""
+    tmp_path = fmuconfig_with_output
+    cfg = find_global_config(tmp_path, strict=False)
+    assert cfg is not None
+    fmu_dir = init_fmu_directory(tmp_path, global_config=cfg)
+    config = fmu_dir.config.load()
+    assert config.masterdata is not None
+    assert config.masterdata.smda.field[0].identifier == "DROGON"
+
+    assert config.model is not None
+    assert config.model.name == "Drogon"
+
+    assert config.access is not None
+    assert config.access.asset.name == "Drogon"
 
 
 def test_readme_is_written(tmp_path: Path, config_model: ProjectConfig) -> None:


### PR DESCRIPTION
Resolves #64

Sorry for the intimidating line count, but it is mostly tests!

This adds a dependency on fmu-config with a new nice requirements:

- Can import either global _config_ (input, split config), or global _variables_ (output, compiled config)
- Does strict checking to refuse importing Drogon master data
- Imports existing global config masterdata into the .fmu config, but as extra input
- Can be used to do either of these things from the API now
- Reason for splitting this out here: can also be done with an `fmu init` commands from the CLI package too

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
