### PR TITLE
ENH: Separate 'is_locked' and 'is_acquired'

### DIFF
--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -333,7 +333,7 @@ def test_acquire_lock_on_project_fmu(
 ) -> None:
     """Tests that a lock can be acquired on the project dir."""
     fmu_dir._lock.acquire()
-    assert fmu_dir._lock.is_locked()
+    assert fmu_dir._lock.is_acquired()
     assert fmu_dir._lock.exists
     assert (fmu_dir.path / ".lock").exists()
 
@@ -343,6 +343,6 @@ def test_acquire_lock_on_user_fmu(
 ) -> None:
     """Tests that a lock can be acquired on the user dir."""
     user_fmu_dir._lock.acquire()
-    assert user_fmu_dir._lock.is_locked()
+    assert user_fmu_dir._lock.is_acquired()
     assert user_fmu_dir._lock.exists
     assert (user_fmu_dir.path / ".lock").exists()


### PR DESCRIPTION
Resolves #67

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
