### PR TITLE
MAINT: Make config_manager generic

### DIFF
--- a/src/fmu/settings/_resources/config_managers.py
+++ b/src/fmu/settings/_resources/config_managers.py
@@ -3,208 +3,47 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Self, TypeVar
-
-from pydantic import ValidationError
+from typing import TYPE_CHECKING, Final, Self
 
 from fmu.settings._logging import null_logger
 from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.models.user_config import UserConfig
-from fmu.settings.types import ResettableBaseModel  # noqa: TC001
 
-from .pydantic_resource_manager import PydanticResourceManager
+from .pydantic_resource_manager import (
+    MutablePydanticResourceManager,
+)
 
 if TYPE_CHECKING:
     # Avoid circular dependency for type hint in __init__ only
     from fmu.settings._fmu_dir import (
-        FMUDirectoryBase,
         ProjectFMUDirectory,
         UserFMUDirectory,
     )
 
 logger: Final = null_logger(__name__)
 
-T = TypeVar("T", bound=ResettableBaseModel)
 
-
-class ConfigManager(PydanticResourceManager[T]):
-    """Manages the .fmu configuration file."""
-
-    def __init__(self: Self, fmu_dir: FMUDirectoryBase, config: type[T]) -> None:
-        """Initializes the Config resource manager."""
-        super().__init__(fmu_dir, config)
-
-    @property
-    def relative_path(self: Self) -> Path:
-        """Returns the relative path to the config file."""
-        return Path("config.json")
-
-    def _get_dot_notation_key(
-        self: Self, config_dict: dict[str, Any], key: str, default: Any = None
-    ) -> Any:
-        """Sets the value to a dot-notation key.
-
-        Args:
-            config_dict: The configuration dictionary we are modifying (by reference)
-            key: The key to set
-            default: Value to return if key is not found. Default None
-
-        Returns:
-            The value or default
-        """
-        parts = key.split(".")
-        value = config_dict
-        for part in parts:
-            if isinstance(value, dict) and part in value:
-                value = value[part]
-            else:
-                return default
-
-        return value
-
-    def get(self: Self, key: str, default: Any = None) -> Any:
-        """Gets a configuration value by key.
-
-        Supports dot notation for nested values (e.g., "foo.bar")
-
-        Args:
-            key: The configuration key
-            default: Value to return if key is not found. Default None
-
-        Returns:
-            The configuration value or default
-        """
-        try:
-            config = self.load()
-
-            if "." in key:
-                return self._get_dot_notation_key(config.model_dump(), key, default)
-
-            if hasattr(config, key):
-                return getattr(config, key)
-
-            config_dict = config.model_dump()
-            return config_dict.get(key, default)
-        except FileNotFoundError as e:
-            raise FileNotFoundError(
-                f"Resource file for '{self.__class__.__name__}' not found "
-                f"at: '{self.path}' when getting key {key}"
-            ) from e
-
-    def _set_dot_notation_key(
-        self: Self, config_dict: dict[str, Any], key: str, value: Any
-    ) -> None:
-        """Sets the value to a dot-notation key.
-
-        Args:
-            config_dict: The configuration dictionary we are modifying (by reference)
-            key: The key to set
-            value: The value to set
-        """
-        parts = key.split(".")
-        target = config_dict
-
-        for part in parts[:-1]:
-            if part not in target or not isinstance(target[part], dict):
-                target[part] = {}
-            target = target[part]
-
-        target[parts[-1]] = value
-
-    def set(self: Self, key: str, value: Any) -> None:
-        """Sets a configuration value by key.
-
-        Args:
-            key: The configuration key
-            value: The value to set
-
-        Raises:
-            FileNotFoundError: If config file doesn't exist
-            ValueError: If the updated config is invalid
-        """
-        try:
-            config = self.load()
-            config_dict = config.model_dump()
-
-            if "." in key:
-                self._set_dot_notation_key(config_dict, key, value)
-            else:
-                config_dict[key] = value
-
-            updated_config = config.model_validate(config_dict)
-            self.save(updated_config)
-        except ValidationError as e:
-            raise ValueError(
-                f"Invalid value set for '{self.__class__.__name__}' with "
-                f"key '{key}', value '{value}': '{e}"
-            ) from e
-        except FileNotFoundError as e:
-            raise FileNotFoundError(
-                f"Resource file for '{self.__class__.__name__}' not found "
-                f"at: '{self.path}' when setting key {key}"
-            ) from e
-
-    def update(self: Self, updates: dict[str, Any]) -> T:
-        """Updates multiple configuration values at once.
-
-        Args:
-            updates: Dictionary of key-value pairs to update
-
-        Returns:
-            The updated Config object
-
-        Raises:
-            FileNotFoundError: If config file doesn't exist
-            ValueError: If the updates config is invalid
-        """
-        try:
-            config = self.load()
-            config_dict = config.model_dump()
-
-            flat_updates = {k: v for k, v in updates.items() if "." not in k}
-            config_dict.update(flat_updates)
-
-            for key, value in updates.items():
-                if "." in key:
-                    self._set_dot_notation_key(config_dict, key, value)
-
-                updated_config = config.model_validate(config_dict)
-            self.save(updated_config)
-        except ValidationError as e:
-            raise ValueError(
-                f"Invalid value set for '{self.__class__.__name__}' with "
-                f"updates '{updates}': '{e}"
-            ) from e
-        except FileNotFoundError as e:
-            raise FileNotFoundError(
-                f"Resource file for '{self.__class__.__name__}' not found "
-                f"at: '{self.path}' when setting updates {updates}"
-            ) from e
-
-        return updated_config
-
-    def reset(self: Self) -> T:
-        """Resets the configuration to defaults.
-
-        Returns:
-            The new default config object
-        """
-        config = self.model_class.reset()
-        self.save(config)
-        return config
-
-
-class ProjectConfigManager(ConfigManager[ProjectConfig]):
+class ProjectConfigManager(MutablePydanticResourceManager[ProjectConfig]):
     """Manages the .fmu configuration file in a project."""
 
     def __init__(self: Self, fmu_dir: ProjectFMUDirectory) -> None:
         """Initializes the ProjectConfig resource manager."""
         super().__init__(fmu_dir, ProjectConfig)
 
+    @property
+    def relative_path(self: Self) -> Path:
+        """Returns the relative path to the config file."""
+        return Path("config.json")
 
-class UserConfigManager(ConfigManager[UserConfig]):
+
+class UserConfigManager(MutablePydanticResourceManager[UserConfig]):
     """Manages the .fmu configuration file in a user's home directory."""
 
     def __init__(self: Self, fmu_dir: UserFMUDirectory) -> None:
         """Initializes the UserConfig resource manager."""
         super().__init__(fmu_dir, UserConfig)
+
+    @property
+    def relative_path(self: Self) -> Path:
+        """Returns the relative path to the config file."""
+        return Path("config.json")

--- a/src/fmu/settings/_resources/pydantic_resource_manager.py
+++ b/src/fmu/settings/_resources/pydantic_resource_manager.py
@@ -3,23 +3,28 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
+from fmu.settings.types import ResettableBaseModel
+
 if TYPE_CHECKING:
+    # Avoid circular dependency for type hint in __init__ only
     from pathlib import Path
 
-    # Avoid circular dependency for type hint in __init__ only
     from fmu.settings._fmu_dir import FMUDirectoryBase
 
-T = TypeVar("T", bound=BaseModel)
+PydanticResource = TypeVar("PydanticResource", bound=BaseModel)
+MutablePydanticResource = TypeVar("MutablePydanticResource", bound=ResettableBaseModel)
 
 
-class PydanticResourceManager(Generic[T]):
+class PydanticResourceManager(Generic[PydanticResource]):
     """Base class for managing resources represented by Pydantic models."""
 
-    def __init__(self: Self, fmu_dir: FMUDirectoryBase, model_class: type[T]) -> None:
+    def __init__(
+        self: Self, fmu_dir: FMUDirectoryBase, model_class: type[PydanticResource]
+    ) -> None:
         """Initializes the resource manager.
 
         Args:
@@ -28,7 +33,7 @@ class PydanticResourceManager(Generic[T]):
         """
         self.fmu_dir = fmu_dir
         self.model_class = model_class
-        self._cache: T | None = None
+        self._cache: PydanticResource | None = None
 
     @property
     def relative_path(self: Self) -> Path:
@@ -48,7 +53,9 @@ class PydanticResourceManager(Generic[T]):
         """Returns whether or not the resource exists."""
         return self.path.exists()
 
-    def load(self: Self, force: bool = False, store_cache: bool = True) -> T:
+    def load(
+        self: Self, force: bool = False, store_cache: bool = True
+    ) -> PydanticResource:
         """Loads the resource from disk and validates it as a Pydantic model.
 
         Args:
@@ -92,7 +99,7 @@ class PydanticResourceManager(Generic[T]):
 
         return self._cache
 
-    def save(self: Self, model: T) -> None:
+    def save(self: Self, model: PydanticResource) -> None:
         """Save the Pydantic model to disk.
 
         Args:
@@ -102,3 +109,167 @@ class PydanticResourceManager(Generic[T]):
         json_data = model.model_dump_json(by_alias=True, indent=2)
         self.fmu_dir.write_text_file(self.relative_path, json_data)
         self._cache = model
+
+
+class MutablePydanticResourceManager(PydanticResourceManager[MutablePydanticResource]):
+    """Manages the .fmu configuration file."""
+
+    def __init__(
+        self: Self, fmu_dir: FMUDirectoryBase, config: type[MutablePydanticResource]
+    ) -> None:
+        """Initializes the Config resource manager."""
+        super().__init__(fmu_dir, config)
+
+    def _get_dot_notation_key(
+        self: Self, config_dict: dict[str, Any], key: str, default: Any = None
+    ) -> Any:
+        """Sets the value to a dot-notation key.
+
+        Args:
+            config_dict: The configuration dictionary we are modifying (by reference)
+            key: The key to set
+            default: Value to return if key is not found. Default None
+
+        Returns:
+            The value or default
+        """
+        parts = key.split(".")
+        value = config_dict
+        for part in parts:
+            if isinstance(value, dict) and part in value:
+                value = value[part]
+            else:
+                return default
+
+        return value
+
+    def get(self: Self, key: str, default: Any = None) -> Any:
+        """Gets a configuration value by key.
+
+        Supports dot notation for nested values (e.g., "foo.bar")
+
+        Args:
+            key: The configuration key
+            default: Value to return if key is not found. Default None
+
+        Returns:
+            The configuration value or default
+        """
+        try:
+            config = self.load()
+
+            if "." in key:
+                return self._get_dot_notation_key(config.model_dump(), key, default)
+
+            if hasattr(config, key):
+                return getattr(config, key)
+
+            config_dict = config.model_dump()
+            return config_dict.get(key, default)
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"Resource file for '{self.__class__.__name__}' not found "
+                f"at: '{self.path}' when getting key {key}"
+            ) from e
+
+    def _set_dot_notation_key(
+        self: Self, config_dict: dict[str, Any], key: str, value: Any
+    ) -> None:
+        """Sets the value to a dot-notation key.
+
+        Args:
+            config_dict: The configuration dictionary we are modifying (by reference)
+            key: The key to set
+            value: The value to set
+        """
+        parts = key.split(".")
+        target = config_dict
+
+        for part in parts[:-1]:
+            if part not in target or not isinstance(target[part], dict):
+                target[part] = {}
+            target = target[part]
+
+        target[parts[-1]] = value
+
+    def set(self: Self, key: str, value: Any) -> None:
+        """Sets a configuration value by key.
+
+        Args:
+            key: The configuration key
+            value: The value to set
+
+        Raises:
+            FileNotFoundError: If config file doesn't exist
+            ValueError: If the updated config is invalid
+        """
+        try:
+            config = self.load()
+            config_dict = config.model_dump()
+
+            if "." in key:
+                self._set_dot_notation_key(config_dict, key, value)
+            else:
+                config_dict[key] = value
+
+            updated_config = config.model_validate(config_dict)
+            self.save(updated_config)
+        except ValidationError as e:
+            raise ValueError(
+                f"Invalid value set for '{self.__class__.__name__}' with "
+                f"key '{key}', value '{value}': '{e}"
+            ) from e
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"Resource file for '{self.__class__.__name__}' not found "
+                f"at: '{self.path}' when setting key {key}"
+            ) from e
+
+    def update(self: Self, updates: dict[str, Any]) -> MutablePydanticResource:
+        """Updates multiple configuration values at once.
+
+        Args:
+            updates: Dictionary of key-value pairs to update
+
+        Returns:
+            The updated Config object
+
+        Raises:
+            FileNotFoundError: If config file doesn't exist
+            ValueError: If the updates config is invalid
+        """
+        try:
+            config = self.load()
+            config_dict = config.model_dump()
+
+            flat_updates = {k: v for k, v in updates.items() if "." not in k}
+            config_dict.update(flat_updates)
+
+            for key, value in updates.items():
+                if "." in key:
+                    self._set_dot_notation_key(config_dict, key, value)
+
+                updated_config = config.model_validate(config_dict)
+            self.save(updated_config)
+        except ValidationError as e:
+            raise ValueError(
+                f"Invalid value set for '{self.__class__.__name__}' with "
+                f"updates '{updates}': '{e}"
+            ) from e
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"Resource file for '{self.__class__.__name__}' not found "
+                f"at: '{self.path}' when setting updates {updates}"
+            ) from e
+
+        return updated_config
+
+    def reset(self: Self) -> MutablePydanticResource:
+        """Resets the configuration to defaults.
+
+        Returns:
+            The new default config object
+        """
+        config = self.model_class.reset()
+        self.save(config)
+        return config


### PR DESCRIPTION
Resolves #50 

Rename ConfigManager to MutablePydanticResourceManager, move it to pydantic_resource_manager.py, remove the relative_path property, and have the child ConfigManager classes implement it instead.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
