### PR TITLE
BUG: Propagate ValidationError to find_global_config

### DIFF
--- a/src/fmu/settings/_global_config.py
+++ b/src/fmu/settings/_global_config.py
@@ -145,16 +145,18 @@ def load_global_configuration_if_present(
         fmu_load: Whether or not to load in the custom 'fmu' format. Default False.
 
     Returns:
-        GlobalConfiguration instance or None.
+        GlobalConfiguration instance or None if file cannot be loaded.
+
+    Raises:
+        ValidationError: If the file is loaded but has invalid schema.
     """
     loader = "fmu" if fmu_load else "standard"
     try:
         global_variables_dict = yaml_load(path, loader=loader)
         global_config = GlobalConfiguration.model_validate(global_variables_dict)
         logger.debug(f"Global variables at {path} has valid settings data")
-    except ValidationError as e:
-        logger.debug(f"Global variables at {path} failed validation: {e}")
-        return None
+    except ValidationError:
+        raise
     except Exception as e:
         logger.debug(
             f"Failed to load global variables at {path}: {type(e).__name__}: {e}"
@@ -173,6 +175,9 @@ def _find_global_variables_file(paths: list[Path]) -> GlobalConfiguration | None
 
     Returns:
         A validated GlobalConfiguration or None.
+
+    Raises:
+        ValidationError: If a file is found but has invalid schema.
     """
     for path in paths:
         if not path.exists():
@@ -204,6 +209,9 @@ def _find_global_config_file(paths: list[Path]) -> GlobalConfiguration | None:
 
     Returns:
         A validated GlobalConfiguration or None.
+
+    Raises:
+        ValidationError: If a file is found but has invalid schema.
     """
     for path in paths:
         if not path.exists():
@@ -241,6 +249,11 @@ def find_global_config(
 
     Returns:
         A valid GlobalConfiguration instance, or None.
+
+    Raises:
+        ValidationError: If a configuration file is found but has invalid schema.
+        InvalidGlobalConfigurationError: If strict=True and configuration contains
+            disallowed content (e.g., Drogon data).
     """
     base_path = Path(base_path)
 


### PR DESCRIPTION
Resolves #76 

Propagate `ValidationError` to `find_global_config` so the API can catch it

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
