### PR TITLE
BUG: Invalidate missing lock on refresh

### DIFF
--- a/src/fmu/settings/_resources/lock_manager.py
+++ b/src/fmu/settings/_resources/lock_manager.py
@@ -194,6 +194,8 @@ class LockManager(PydanticResourceManager[LockInfo]):
             LockError: If we don't hold the lock or it's invalid
         """
         if not self.exists:
+            if self.is_acquired():
+                self.release()
             raise LockError("Cannot refresh: lock file does not exist")
 
         lock_info = self._safe_load()

--- a/tests/test_resources/test_lock_manager.py
+++ b/tests/test_resources/test_lock_manager.py
@@ -649,3 +649,18 @@ def test_ensure_can_write_foreign_lock(fmu_dir: ProjectFMUDirectory) -> None:
         pytest.raises(PermissionError, match="Cannot write to .fmu directory"),
     ):
         lock.ensure_can_write()
+
+
+def test_manual_delete_invalidates_lock_file_on_refresh(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests that if a user deletes anothers lock it's invalidated on a refresh."""
+    fmu_dir._lock.acquire()
+    assert fmu_dir._lock.is_acquired() is True
+
+    # Someone deletes the lock
+    fmu_dir._lock.path.unlink()
+
+    with pytest.raises(LockError, match="Cannot refresh: lock file does not exist"):
+        fmu_dir._lock.refresh()
+    assert fmu_dir._lock.is_acquired() is False


### PR DESCRIPTION
Resolves #83 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
