### PR TITLE
FIX: Raise special exception on lock not found

### DIFF
--- a/src/fmu/settings/_resources/lock_manager.py
+++ b/src/fmu/settings/_resources/lock_manager.py
@@ -32,6 +32,10 @@ class LockError(Exception):
     """Raised when the lock cannot be acquired."""
 
 
+class LockNotFoundError(FileNotFoundError):
+    """Raised when the lock cannot be found."""
+
+
 class LockManager(PydanticResourceManager[LockInfo]):
     """Manages the .lock file."""
 
@@ -196,7 +200,7 @@ class LockManager(PydanticResourceManager[LockInfo]):
         if not self.exists:
             if self.is_acquired():
                 self.release()
-            raise LockError("Cannot refresh: lock file does not exist")
+            raise LockNotFoundError("Cannot refresh: lock file does not exist")
 
         lock_info = self._safe_load()
         if not lock_info or not self._is_mine(lock_info):


### PR DESCRIPTION
Resolves #86 

Will provide more precise handling on the API side. https://github.com/equinor/fmu-settings-api/issues/154

Also merged two redundant tests into a single, better test.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
