### PR TITLE
ENH: Create a `UserSessionLogManager`

### DIFF
--- a/src/fmu/settings/_resources/lock_manager.py
+++ b/src/fmu/settings/_resources/lock_manager.py
@@ -39,7 +39,7 @@ class LockNotFoundError(FileNotFoundError):
 class LockManager(PydanticResourceManager[LockInfo]):
     """Manages the .lock file."""
 
-    cache_enabled: bool = False
+    automatic_caching: bool = False
 
     def __init__(
         self: Self,

--- a/src/fmu/settings/_resources/log_manager.py
+++ b/src/fmu/settings/_resources/log_manager.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 class LogManager(PydanticResourceManager[Log[LogEntryType]], Generic[LogEntryType]):
     """Manages the .fmu log files."""
 
-    cache_enabled: bool = False
+    automatic_caching: bool = False
 
     def __init__(
         self: Self, fmu_dir: FMUDirectoryBase, model_class: type[Log[LogEntryType]]

--- a/src/fmu/settings/_resources/pydantic_resource_manager.py
+++ b/src/fmu/settings/_resources/pydantic_resource_manager.py
@@ -24,7 +24,7 @@ MutablePydanticResource = TypeVar("MutablePydanticResource", bound=ResettableBas
 class PydanticResourceManager(Generic[PydanticResource]):
     """Base class for managing resources represented by Pydantic models."""
 
-    cache_enabled: bool = True
+    automatic_caching: bool = True
 
     def __init__(
         self: Self, fmu_dir: FMUDirectoryBase, model_class: type[PydanticResource]
@@ -140,7 +140,7 @@ class PydanticResourceManager(Generic[PydanticResource]):
         json_data = model.model_dump_json(by_alias=True, indent=2)
         self.fmu_dir.write_text_file(self.relative_path, json_data)
 
-        if self.cache_enabled and self.exists:
+        if self.automatic_caching and self.exists:
             self.fmu_dir.cache.store_revision(self.relative_path, json_data)
 
         self._cache = model

--- a/src/fmu/settings/_resources/user_session_log_manager.py
+++ b/src/fmu/settings/_resources/user_session_log_manager.py
@@ -1,4 +1,4 @@
-"""Manages an .fmu userlog file."""
+"""Manages an .fmu user_session_log file."""
 
 from __future__ import annotations
 
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Self
 
 from fmu.settings._resources.log_manager import LogManager
+from fmu.settings.models.event_info import EventInfo
 from fmu.settings.models.log import Log, LogFileName
-from fmu.settings.models.user_info import UserInfo
 
 if TYPE_CHECKING:
     # Avoid circular dependency for type hint in __init__ only
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
     )
 
 
-class UserlogManager(LogManager[UserInfo]):
+class UserSessionLogManager(LogManager[EventInfo]):
     """Manages the .fmu userlog file."""
 
     def __init__(self: Self, fmu_dir: FMUDirectoryBase) -> None:
         """Initializes the User log resource manager."""
-        super().__init__(fmu_dir, Log[UserInfo])
+        super().__init__(fmu_dir, Log[EventInfo])
 
         # If userlog.json exists from previous session, cache it and then delete it
         # We want a fresh log each time
@@ -36,4 +36,4 @@ class UserlogManager(LogManager[UserInfo]):
     @property
     def relative_path(self: Self) -> Path:
         """Returns the relative path to the log file."""
-        return Path("logs") / LogFileName.userlog
+        return Path("logs") / LogFileName.user_session_log

--- a/src/fmu/settings/models/event_info.py
+++ b/src/fmu/settings/models/event_info.py
@@ -5,8 +5,8 @@ from datetime import UTC, datetime
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
-class UserInfo(BaseModel):
-    """Log entry model for fmu-settings LogManager."""
+class EventInfo(BaseModel):
+    """Represents information about user session activity."""
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/fmu/settings/models/log.py
+++ b/src/fmu/settings/models/log.py
@@ -60,4 +60,4 @@ class LogFileName(StrEnum):
     """The log files in the .fmu directory."""
 
     changelog = "changelog.json"
-    userlog = "userlog.json"
+    user_session_log = "user_session_log.json"

--- a/tests/test_resources/test_resource_managers.py
+++ b/tests/test_resources/test_resource_managers.py
@@ -191,8 +191,8 @@ def test_pydantic_resource_manager_save_does_not_cache_when_disabled(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Saving without cache enabled should not create cache artifacts."""
-    original_default = AManager.cache_enabled
-    AManager.cache_enabled = False
+    original_default = AManager.automatic_caching
+    AManager.automatic_caching = False
     cache_root = fmu_dir.path / "cache"
     try:
         if cache_root.exists():
@@ -200,7 +200,7 @@ def test_pydantic_resource_manager_save_does_not_cache_when_disabled(
         a = AManager(fmu_dir)
         a.save(A(foo="bar"))
     finally:
-        AManager.cache_enabled = original_default
+        AManager.automatic_caching = original_default
 
     assert not cache_root.exists()
 


### PR DESCRIPTION
Resolves #47 

With the previous implementation, every time the `save()` method is called from `LogManager` (in both `ChangelogManager` and `UserlogManager`), it creates a new revision (cache) file. We don't want this behavior for either manager because:

- For `ChangelogManager`: It would create a new cache file for every single config change, which is unnecessary.

- For `UserlogManager`: It would create a new cache file for every single event logged during a session, but we want to cache only **complete sessions** (the entire `userlog.json` after a session finishes), not every individual entry.

Solution:

We disable automatic caching in `LogManager` by setting `cache_enabled = False`. However, we still want to preserve the last 5 complete user sessions for historical reference.

Therefore, in `UserlogManager.__init__()`:

1. Check if `userlog.json` exists from a previous session
2. If it exists, manually cache it (via `cache.store_revision()`, not through `save()`) to preserve the complete session
3. Delete the file to start a fresh session
4. When new activities occur, a new `userlog.json` is created and logs accumulate until the session ends

Result: We can review the last 5 complete user sessions from the cache without needing timestamps in the filename, while the current `userlog.json` always represents the active session.

P.S. We don't have a retain policy yet, but we have auto deletion after 5 sessions. This may be too low for session logs? Maybe better to implement no revision limit but 30 days retention default like the issue description? But there should be more changes to implement this either in `CacheManager` or directly in `UserlogManager`.

P.P.S. `UserlogManager` is not used in fmu-settings currently, as it meant to be used by the API. Should we use it here as well?

So wdyt? @mferrera @slangeveld

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
