### PR TITLE
ENH: Store info about RmsProject in project config

### DIFF
--- a/src/fmu/settings/models/project_config.py
+++ b/src/fmu/settings/models/project_config.py
@@ -5,11 +5,18 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Self
 
-from pydantic import AwareDatetime, Field
+from pydantic import AwareDatetime, BaseModel, Field
 
 from fmu.datamodels.fmu_results.fields import Access, Masterdata, Model
 from fmu.settings import __version__
 from fmu.settings.types import ResettableBaseModel, VersionStr  # noqa: TC001
+
+
+class RmsProject(BaseModel):
+    """RMS project configuration."""
+
+    path: Path
+    version: str
 
 
 class ProjectConfig(ResettableBaseModel):
@@ -25,7 +32,7 @@ class ProjectConfig(ResettableBaseModel):
     model: Model | None = Field(default=None)
     access: Access | None = Field(default=None)
     cache_max_revisions: int = Field(default=5, ge=5)
-    rms_project_path: Path | None = Field(default=None)
+    rms: RmsProject | None = Field(default=None)
 
     @classmethod
     def reset(cls: type[Self]) -> Self:
@@ -42,5 +49,5 @@ class ProjectConfig(ResettableBaseModel):
             model=None,
             access=None,
             cache_max_revisions=5,
-            rms_project_path=None,
+            rms=None,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
         "masterdata": None,
         "model": None,
         "access": None,
-        "rms_project_path": None,
+        "rms": None,
     }
 
 

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -592,13 +592,13 @@ def test_find_rms_projects_with_config_path(
     (rms_project / ".master").write_text("content")
     (rms_project / "rms.ini").write_text("[RMS]")
 
-    fmu_dir.set_config_value("rms_project_path", rms_project)
+    fmu_dir.set_config_value("rms", {"path": str(rms_project), "version": "14.2.2"})
 
-    stored_path = fmu_dir.get_config_value("rms_project_path")
-    assert stored_path == rms_project
+    stored_rms = fmu_dir.get_config_value("rms")
+    assert stored_rms.path == rms_project
 
     fmu_dir2 = ProjectFMUDirectory(fmu_dir.base_path)
-    assert fmu_dir2.get_config_value("rms_project_path") == rms_project
+    assert fmu_dir2.get_config_value("rms").path == rms_project
 
 
 def test_fmu_directory_base_get_dir_diff_with_other_fmu_dir(


### PR DESCRIPTION
Resolves #116

with this change, PATCH /rms_project_path endpoint will change to PATCH /rms, which will take the selected rms project path and set the rms.path and rms.version in the project config file

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
