### PR TITLE
ENH: Add support for diff and sync of changelog

### DIFF
--- a/src/fmu/settings/models/change_info.py
+++ b/src/fmu/settings/models/change_info.py
@@ -3,7 +3,8 @@
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pydantic import AwareDatetime, BaseModel, Field
+import pandas as pd
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
 
 from fmu.settings.models._enums import ChangeType
 
@@ -11,7 +12,9 @@ from fmu.settings.models._enums import ChangeType
 class ChangeInfo(BaseModel):
     """Represents a change in the changelog file."""
 
-    timestamp: AwareDatetime = Field(default_factory=lambda: datetime.now(UTC))
+    timestamp: AwareDatetime = Field(
+        default_factory=lambda: datetime.now(UTC), strict=True
+    )
     change_type: ChangeType
     user: str
     path: Path
@@ -19,3 +22,16 @@ class ChangeInfo(BaseModel):
     hostname: str
     file: str
     key: str
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def convert_timestamp(cls, value: str) -> AwareDatetime:
+        """Convert timestamp values given as a 'str' or Pandas 'Timestamp'.
+
+        Values of other types will be handled by Pydantic.
+        """
+        if isinstance(value, str):
+            return datetime.fromisoformat(value)
+        if isinstance(value, pd.Timestamp):
+            return value.to_pydatetime()
+        return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,6 +340,23 @@ def fmu_dir(tmp_path: Path, unix_epoch_utc: datetime) -> ProjectFMUDirectory:
         return init_fmu_directory(tmp_path)
 
 
+@pytest.fixture(scope="function")
+def extra_fmu_dir(tmp_path: Path, unix_epoch_utc: datetime) -> ProjectFMUDirectory:
+    """Create an extra ProjectFMUDirectory instance for testing of diff and sync."""
+    extra_fmu_path = tmp_path / Path("extra_fmu")
+    extra_fmu_path.mkdir(parents=True)
+    with (
+        patch(
+            "fmu.settings.models.project_config.getpass.getuser",
+            return_value="user",
+        ),
+        patch("fmu.settings.models.project_config.datetime") as mock_datetime,
+    ):
+        mock_datetime.now.return_value = unix_epoch_utc
+        mock_datetime.datetime.now.return_value = unix_epoch_utc
+        return init_fmu_directory(extra_fmu_path)
+
+
 @pytest.fixture
 def user_fmu_dir(tmp_path: Path, unix_epoch_utc: datetime) -> UserFMUDirectory:
     """Create an ProjectFMUDirectory instance for testing."""


### PR DESCRIPTION
Resolves #118 

Add functionality for `diff` and `sync` for the changelog. This includes:
* Methods to `diff` and `merge` two different changelog resources
* Diff and sync of `.fmu` now also `diff` and `sync` the changelog.

To get the diff between two changelogs, we use the timestamp of the latest change entry in the current changelog to dertemine which change entries that are of interest. All change entries from the incoming changelog that are newer than this, will be returned as the diff.

When merging two changelogs, we get the diff and add all the log entries in the diff to the current changelog.

In addition to this, the runtime variable `cache_max_revisions` is now also synced as part of the `.fmu` sync.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
