### PR TITLE
ENH: Add filter operators '>' and '<'

### DIFF
--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -104,7 +104,7 @@ class ChangelogManager(LogManager[ChangeInfo]):
                     field_name="timestamp",
                     filter_value=str(starting_point),
                     filter_type=FilterType.date,
-                    operator=">=",
+                    operator=">",
                 )
             )
         raise FileNotFoundError(

--- a/src/fmu/settings/_resources/log_manager.py
+++ b/src/fmu/settings/_resources/log_manager.py
@@ -52,6 +52,17 @@ class LogManager(PydanticResourceManager[Log[LogEntryType]], Generic[LogEntryTyp
             self._cached_dataframe = df_log
         df_log = self._cached_dataframe
 
+        if filter.filter_type == FilterType.text and filter.operator not in {
+            "==",
+            "!=",
+        }:
+            raise ValueError(
+                f"Invalid filter operator {filter.operator} applied to "
+                f"'{FilterType.text}' field {filter.field_name} when filtering "
+                f"log resource {self.model_class.__name__} "
+                f"with value {filter.filter_value}."
+            )
+
         match filter.operator:
             case "==":
                 filtered_df = df_log[
@@ -62,24 +73,20 @@ class LogManager(PydanticResourceManager[Log[LogEntryType]], Generic[LogEntryTyp
                     df_log[filter.field_name] != filter.parse_filter_value()
                 ]
             case "<=":
-                if filter.filter_type == FilterType.text:
-                    raise ValueError(
-                        f"Invalid filter operator <= applied to '{FilterType.text}' "
-                        f"field {filter.field_name} when filtering log resource "
-                        f"{self.model_class.__name__} with value {filter.filter_value}."
-                    )
                 filtered_df = df_log[
                     df_log[filter.field_name] <= filter.parse_filter_value()
                 ]
+            case "<":
+                filtered_df = df_log[
+                    df_log[filter.field_name] < filter.parse_filter_value()
+                ]
             case ">=":
-                if filter.filter_type == FilterType.text:
-                    raise ValueError(
-                        f"Invalid filter operator >= applied to '{FilterType.text}' "
-                        f"field {filter.field_name} when filtering log resource "
-                        f"{self.model_class.__name__} with value {filter.filter_value}."
-                    )
                 filtered_df = df_log[
                     df_log[filter.field_name] >= filter.parse_filter_value()
+                ]
+            case ">":
+                filtered_df = df_log[
+                    df_log[filter.field_name] > filter.parse_filter_value()
                 ]
             case _:
                 raise ValueError(

--- a/src/fmu/settings/models/log.py
+++ b/src/fmu/settings/models/log.py
@@ -39,7 +39,7 @@ class Filter(BaseModel):
     field_name: str
     filter_value: str
     filter_type: FilterType
-    operator: Literal[">=", "<=", "==", "!="]
+    operator: Literal[">", ">=", "<", "<=", "==", "!="]
 
     def parse_filter_value(self: Self) -> str | datetime | int:
         """Parse filter value to its type."""


### PR DESCRIPTION
Resolves #134 

Add support for filter operators `>` and `<` when filtering logs.

Updated the `get_changelog_diff` method to use `>` instead of `>=` to actually return all log entries newer than the existing entries (and not newer or same age).

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
