### PR TITLE
TYP: Fix error message

### DIFF
--- a/src/fmu/settings/_global_config.py
+++ b/src/fmu/settings/_global_config.py
@@ -127,7 +127,7 @@ def validate_global_configuration_strictly(cfg: GlobalConfiguration) -> None:  #
         for key in cfg.stratigraphy:
             if key.lower() in INVALID_STRAT_NAMES:
                 raise InvalidGlobalConfigurationError(
-                    f"Invalid stratigraphy name in 'smda.stratigraphy': {key}"
+                    f"Invalid stratigraphy name in 'cfg.stratigraphy': {key}"
                 )
 
 

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -283,7 +283,7 @@ def test_validate_global_config_strict_stratigraphy_names(
     else:
         with pytest.raises(
             InvalidGlobalConfigurationError,
-            match=f"Invalid stratigraphy name in 'smda.stratigraphy': {identifier}",
+            match=f"Invalid stratigraphy name in 'cfg.stratigraphy': {identifier}",
         ):
             validate_global_configuration_strictly(cfg)
 


### PR DESCRIPTION
Resolves #131 

Fixed the error message from `smda.stratigraphy` to calling the global config stratigraphy `cfg.stratigraphy`. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
