### PR TITLE
ENH: Add properties for mappings and changelog

### DIFF
--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -99,6 +99,16 @@ class FMUDirectoryBase:
         self._cache_manager.max_revisions = clamped_value
         self.set_config_value("cache_max_revisions", clamped_value)
 
+    @property
+    def changelog(self: Self) -> ChangelogManager:
+        """Access the ChangelogManager."""
+        return self._changelog
+
+    @property
+    def mappings(self: Self) -> MappingsManager:
+        """Access the MappingsManager."""
+        return self._mappings
+
     def get_config_value(self: Self, key: str, default: Any = None) -> Any:
         """Gets a configuration value by key.
 

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -25,7 +25,9 @@ from fmu.settings._fmu_dir import (
     UserFMUDirectory,
 )
 from fmu.settings._readme_texts import PROJECT_README_CONTENT, USER_README_CONTENT
+from fmu.settings._resources.changelog_manager import ChangelogManager
 from fmu.settings._resources.lock_manager import DEFAULT_LOCK_TIMEOUT, LockManager
+from fmu.settings._resources.mappings_manager import MappingsManager
 from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.change_info import ChangeInfo
 from fmu.settings.models.log import Log
@@ -147,6 +149,22 @@ def test_set_cache_max_revisions_updates_manager(
     fmu_dir.cache_max_revisions = 7
 
     assert cache.max_revisions == 7  # noqa: PLR2004
+
+
+def test_changelog_property_returns_changelog_manager(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Changelog manager should be memoized and ready for use."""
+    assert isinstance(fmu_dir.changelog, ChangelogManager)
+    assert fmu_dir.changelog is fmu_dir._changelog
+
+
+def test_mappings_property_returns_mappings_manager(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Mappings manager should be memoized and ready for use."""
+    assert isinstance(fmu_dir.mappings, MappingsManager)
+    assert fmu_dir.mappings is fmu_dir._mappings
 
 
 def test_get_config_value(fmu_dir: ProjectFMUDirectory) -> None:


### PR DESCRIPTION
This is depedency to resolve https://github.com/equinor/fmu-settings-api/issues/134 in `fmu-settings-api`

Add properties for mappings and changelog resources in `fmu_dir`.

In order to work with the mappings resources from `fmu-settings-api`, we need a way to access the MappingsManager from `fmu_dir`. A new property `mappings` has been added for that purpose.

In addition, a property `changelog` for the ChangelogManager has also been added as we will soon need that for https://github.com/equinor/fmu-settings-api/issues/184

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
