### PR TITLE
BUG: Update lock internal state if lock is not acquired

### DIFF
--- a/src/fmu/settings/_resources/lock_manager.py
+++ b/src/fmu/settings/_resources/lock_manager.py
@@ -179,6 +179,7 @@ class LockManager(PydanticResourceManager[LockInfo]):
 
         current_lock = self.safe_load(force=True, store_cache=False)
         if current_lock is None:
+            self.release()
             return False
 
         return self._is_mine(current_lock) and not self._is_stale()

--- a/tests/test_resources/test_lock_manager.py
+++ b/tests/test_resources/test_lock_manager.py
@@ -437,6 +437,19 @@ def test_is_acquired_expected(
     assert lock.is_acquired() is True
 
 
+def test_is_acquired_after_lock_deleted(
+    fmu_dir: ProjectFMUDirectory, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests is_acquired resets state after the lock file is deleted."""
+    lock = LockManager(fmu_dir)
+    lock.acquire()
+    lock.path.unlink()
+    assert lock.is_acquired() is False
+    lock.acquire()
+    assert lock.is_acquired() is True
+    lock.release()
+
+
 def test_is_acquired_unexpected_members(
     fmu_dir: ProjectFMUDirectory, monkeypatch: MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Resolves #147 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
