### PR TITLE
ENH: Simplify the `MappingGroup` class mappings

### DIFF
--- a/tests/test_mappings_model.py
+++ b/tests/test_mappings_model.py
@@ -55,7 +55,7 @@ def test_mapping_group_serializes_without_system_and_target_fields() -> None:
         mappings=[primary, alias, equivalent],
     )
 
-    display_dict = group.to_display_dict()
+    display_dict = group.model_dump()
     assert display_dict["official_name"] == target_id
     assert display_dict["target_uuid"] == target_uuid
     assert display_dict["mapping_type"] == "stratigraphy"


### PR DESCRIPTION
Resolves #163 

- Added `mapping_type` and `target_uuid` to the mapping view and add validation for them
- Removed redundant fields in mappings list
- The plan for the API is to only call `to_display_dict()`, so that's why I added `target_uuid` as well so no information lost compared to raw mappings.

Example of `to_display_dict()` return value:
```
[
  {
    "target_id": "VOLANTIS GP. Top",
    "target_uuid": "3fa85f64-5717-4562-b3fc-2c963f66af10",
    "mapping_type": "stratigraphy",
    "target_system": "smda",
    "source_system": "rms",
    "mappings": [
      {
        "relation_type": "primary",
        "source_id": "TopVolantis",
        "source_uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa9"
      }
    ]
  },
  {
    "target_id": "VIKING GP.",
    "target_uuid": "3fa85f64-5717-4562-b3fc-2c963f66afb6",
    "mapping_type": "stratigraphy",
    "target_system": "smda",
    "source_system": "rms",
    "mappings": [
      {
        "relation_type": "primary",
        "source_id": "Viking Gp",
        "source_uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa7"
      },
      {
        "relation_type": "alias",
        "source_id": "Viking Group",
        "source_uuid": "3fa85f64-5717-4562-b3fc-2c963f66af43"
      },
      {
        "relation_type": "alias",
        "source_id": "Viking G.",
        "source_uuid": "3fa85f64-5717-4562-b3fc-2c963f66af44"
      },
      {
        "relation_type": "equivalent",
        "source_id": "VIKING GP.",
        "source_uuid": "3fa85f64-5717-4562-b3fc-2c963f66af65"
      }
    ]
  }
]
```

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
