### PR TITLE
ENH: Add method to record copy event to changelog

### DIFF
--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -107,6 +107,21 @@ class ChangelogManager(LogManager[ChangeInfo]):
             )
         )
 
+    def log_copy_revision_to_changelog(self: Self, source_path: Path) -> None:
+        """Logs a change entry with revision copy details to the changelog."""
+        self.add_log_entry(
+            ChangeInfo(
+                timestamp=datetime.now(UTC),
+                change_type=ChangeType.copy,
+                user=os.getenv("USER", "unknown"),
+                path=source_path,
+                change=f"Copied project revision from {source_path}.",
+                hostname=socket.gethostname(),
+                file="N/A",
+                key="project_revision",
+            )
+        )
+
     def _get_latest_change_timestamp(self: Self) -> datetime:
         """Get the timestamp of the latest change entry in the changelog."""
         return self.load()[-1].timestamp

--- a/src/fmu/settings/models/_enums.py
+++ b/src/fmu/settings/models/_enums.py
@@ -42,6 +42,7 @@ class ChangeType(StrEnum):
     add = "add"
     reset = "reset"
     merge = "merge"
+    copy = "copy"
 
 
 class FilterType(StrEnum):

--- a/tests/test_resources/test_changelog_manager.py
+++ b/tests/test_resources/test_changelog_manager.py
@@ -959,3 +959,22 @@ def test_changelog_log_merge_to_changelog_merge_details(
         f"'{incoming_path}' into '{source_path}'."
     )
     assert merge_entry.change == expected_change_string
+
+
+def test_changelog_log_copy_revision_to_changelog(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests that the revision copy details logged to the changelog is as expected."""
+    changelog_resource: ChangelogManager = ChangelogManager(fmu_dir)
+    source_path = Path("path/to/master/project/revision")
+
+    changelog_resource.log_copy_revision_to_changelog(source_path=source_path)
+
+    changelog = changelog_resource.load()
+    assert len(changelog) == 1
+    copy_entry = changelog[0]
+    assert copy_entry.change_type == ChangeType.copy
+    assert copy_entry.path == source_path
+    assert copy_entry.change == f"Copied project revision from {source_path}."
+    assert copy_entry.file == "N/A"
+    assert copy_entry.key == "project_revision"


### PR DESCRIPTION
Resolves #169 

Add logic to the `ChangelogManager` to record a copy event to the changelog. This will be used in `fmu-settings-cli` when copying a project revision to a new revision.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
