### PR TITLE
MAINT: Move changelog and mappings manager to `ProjectFMUDirectory`

### DIFF
--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -16,14 +16,16 @@ from fmu.settings.models.log import Filter, Log, LogFileName
 if TYPE_CHECKING:
     # Avoid circular dependency for type hint in __init__ only
     from fmu.settings._fmu_dir import (
-        FMUDirectoryBase,
+        ProjectFMUDirectory,
     )
 
 
 class ChangelogManager(LogManager[ChangeInfo]):
     """Manages the .fmu changelog file."""
 
-    def __init__(self: Self, fmu_dir: FMUDirectoryBase) -> None:
+    fmu_dir: ProjectFMUDirectory
+
+    def __init__(self: Self, fmu_dir: ProjectFMUDirectory) -> None:
         """Initializes the Change log resource manager."""
         super().__init__(fmu_dir, Log[ChangeInfo])
 

--- a/src/fmu/settings/_resources/mappings_manager.py
+++ b/src/fmu/settings/_resources/mappings_manager.py
@@ -15,14 +15,16 @@ if TYPE_CHECKING:
         StratigraphyMappings,
     )
     from fmu.settings._fmu_dir import (
-        FMUDirectoryBase,
+        ProjectFMUDirectory,
     )
 
 
 class MappingsManager(PydanticResourceManager[Mappings]):
     """Manages the .fmu mappings file."""
 
-    def __init__(self: Self, fmu_dir: FMUDirectoryBase) -> None:
+    fmu_dir: ProjectFMUDirectory
+
+    def __init__(self: Self, fmu_dir: ProjectFMUDirectory) -> None:
         """Initializes the mappings resource manager."""
         super().__init__(fmu_dir, Mappings)
 
@@ -58,7 +60,7 @@ class MappingsManager(PydanticResourceManager[Mappings]):
         mappings.stratigraphy = strat_mappings
         self.save(mappings)
 
-        self.fmu_dir._changelog.log_update_to_changelog(
+        self.fmu_dir.changelog.log_update_to_changelog(
             updates={"stratigraphy": mappings.stratigraphy},
             old_resource_dict=old_mappings_dict,
             relative_path=self.relative_path,

--- a/src/fmu/settings/_resources/pydantic_resource_manager.py
+++ b/src/fmu/settings/_resources/pydantic_resource_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import json
 from builtins import TypeError
 from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
@@ -15,7 +14,6 @@ from fmu.settings.models.diff import (
     ResourceDiff,
     ScalarFieldDiff,
 )
-from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.types import ResettableBaseModel
 
 if TYPE_CHECKING:
@@ -394,7 +392,6 @@ class MutablePydanticResourceManager(PydanticResourceManager[MutablePydanticReso
         try:
             resource = self.load()
             resource_dict = resource.model_dump()
-            old_resource_dict = copy.deepcopy(resource_dict)
 
             if "." in key:
                 self._set_dot_notation_key(resource_dict, key, value)
@@ -403,13 +400,6 @@ class MutablePydanticResourceManager(PydanticResourceManager[MutablePydanticReso
 
             updated_resource = resource.model_validate(resource_dict)
             self.save(updated_resource)
-
-            if self.model_class == ProjectConfig:
-                self.fmu_dir._changelog.log_update_to_changelog(
-                    updates={key: value},
-                    old_resource_dict=old_resource_dict,
-                    relative_path=self.relative_path,
-                )
 
         except ValidationError as e:
             raise ValueError(
@@ -438,7 +428,6 @@ class MutablePydanticResourceManager(PydanticResourceManager[MutablePydanticReso
         try:
             resource = self.load()
             resource_dict = resource.model_dump()
-            old_resource_dict = copy.deepcopy(resource_dict)
 
             flat_updates = {k: v for k, v in updates.items() if "." not in k}
             resource_dict.update(flat_updates)
@@ -449,11 +438,6 @@ class MutablePydanticResourceManager(PydanticResourceManager[MutablePydanticReso
 
             updated_resource = resource.model_validate(resource_dict)
             self.save(updated_resource)
-
-            if self.model_class == ProjectConfig:
-                self.fmu_dir._changelog.log_update_to_changelog(
-                    updates, old_resource_dict, self.relative_path
-                )
 
         except ValidationError as e:
             raise ValueError(


### PR DESCRIPTION
Resolves #179 

As changelog and mappings are only present in project .fmu, we should move the manager out from `FMUDirectoryBase` to `ProjectFMUDirectory`

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
