### PR TITLE
ENH: Allow invalid config when initialize `ProjectFMUDirectory`

### DIFF
--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -1,4 +1,5 @@
 """Main interface for working with .fmu directory."""
+
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Self, TypeAlias, cast

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -96,6 +96,28 @@ def test_init_when_fmu_is_not_a_directory(tmp_path: Path) -> None:
         ProjectFMUDirectory(tmp_path)
 
 
+def test_init_logs_warning_and_uses_default_cache_revisions_on_config_read_error(
+    tmp_path: Path,
+) -> None:
+    """Tests project init falls back to default cache revisions and logs warning."""
+    (tmp_path / ".fmu").mkdir()
+
+    with (
+        patch(
+            "fmu.settings._fmu_dir.ProjectConfigManager.get",
+            side_effect=ValueError("bad config"),
+        ),
+        patch("fmu.settings._fmu_dir.logger.warning") as mock_warning,
+    ):
+        fmu = ProjectFMUDirectory(tmp_path)
+
+    assert fmu.cache.max_revisions == 5  # noqa: PLR2004
+    mock_warning.assert_called_once()
+    warning_message = mock_warning.call_args.args[0]
+    assert "project config" in warning_message
+    assert "bad config" in warning_message
+
+
 def test_find_fmu_directory(fmu_dir: ProjectFMUDirectory) -> None:
     """Tests find_fmu_directory method on nested children."""
     child = fmu_dir.base_path / "child"
@@ -440,6 +462,29 @@ def test_user_init_when_fmu_is_not_a_directory(tmp_path: Path) -> None:
         ),
     ):
         UserFMUDirectory()
+
+
+def test_user_init_logs_warning_and_uses_default_cache_revisions_on_config_read_error(
+    tmp_path: Path,
+) -> None:
+    """Tests user init falls back to default cache revisions and logs warning."""
+    (tmp_path / ".fmu").mkdir()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch(
+            "fmu.settings._fmu_dir.UserConfigManager.get",
+            side_effect=FileNotFoundError("missing"),
+        ),
+        patch("fmu.settings._fmu_dir.logger.warning") as mock_warning,
+    ):
+        fmu = UserFMUDirectory()
+
+    assert fmu.cache.max_revisions == 5  # noqa: PLR2004
+    mock_warning.assert_called_once()
+    warning_message = mock_warning.call_args.args[0]
+    assert "user config" in warning_message
+    assert "missing" in warning_message
 
 
 def test_update_user_config(user_fmu_dir: UserFMUDirectory) -> None:


### PR DESCRIPTION
Resolves #182 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
