### PR TITLE
BUG: Skip caching current state if it is invalid

### DIFF
--- a/src/fmu/settings/_resources/cache_manager.py
+++ b/src/fmu/settings/_resources/cache_manager.py
@@ -166,8 +166,8 @@ class CacheManager:
     ) -> None:
         """Restore a resource file from a cache revision.
 
-        The current state of the resource is automatically cached before overwriting
-        (if the file exists) to enable undo functionality.
+        The current state of the resource is cached before overwriting (if the file
+        exists and validates) to enable undo functionality.
 
         Args:
             resource_file_path: Relative path within the ``.fmu`` directory (e.g.,
@@ -189,7 +189,18 @@ class CacheManager:
 
         if self._fmu_dir.file_exists(resource_file_path):
             current_content = self._fmu_dir.read_text_file(resource_file_path)
-            self.store_revision(resource_file_path, current_content, skip_trim=False)
+
+            try:
+                model_class.model_validate_json(current_content)
+            except ValidationError as e:
+                logger.warning(
+                    "Skipped caching current state of "
+                    f"{resource_file_path} before restore because it is invalid: {e}"
+                )
+            else:
+                self.store_revision(
+                    resource_file_path, current_content, skip_trim=False
+                )
 
         self._fmu_dir.write_text_file(resource_file_path, content_str)
 

--- a/tests/test_resources/test_cache_manager.py
+++ b/tests/test_resources/test_cache_manager.py
@@ -293,3 +293,32 @@ def test_cache_manager_restore_revision_overwrites_and_caches_current(
         if path.suffix == ".json"
     ]
     assert "2.3.4" in cached_versions
+
+
+def test_cache_manager_restore_revision_skips_invalid_current_state_cache(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests that restore_revision does not cache invalid current state."""
+    manager = CacheManager(fmu_dir)
+
+    cached_model = fmu_dir.config.load().model_copy(update={"version": "1.2.3"})
+    snapshot = manager.store_revision(
+        "config.json",
+        cached_model.model_dump_json(by_alias=True, indent=2),
+    )
+    assert snapshot is not None
+
+    fmu_dir.write_text_file("config.json", "invalid json")
+
+    pre_restore = manager.list_revisions("config.json")
+    pre_restore_names = [path.name for path in pre_restore]
+
+    manager.restore_revision("config.json", snapshot.name, ProjectConfig)
+
+    post_restore = manager.list_revisions("config.json")
+    post_restore_names = [path.name for path in post_restore]
+    assert post_restore_names == pre_restore_names
+    assert snapshot.name in post_restore_names
+
+    restored_payload = json.loads(fmu_dir.read_text_file("config.json"))
+    assert restored_payload["version"] == "1.2.3"


### PR DESCRIPTION
Resolves #184 

When we restore a resource, the current state is cached and then gets overwritten with the selected revision. Previously, we don't validate the current state, so invalid state can be cached. We want the cache folder to only have validated content, so with this fix, we validate the current state before caching it, if it's invalid then we do not cache it.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
