### PR TITLE
BUG: Sync `cache_max_revisions` runtime state after config restore

### DIFF
--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -381,6 +381,8 @@ class ProjectFMUDirectory(FMUDirectoryBase):
 
         # Refresh the resource manager's in-memory cache
         manager.load(force=True, store_cache=True)
+        if manager is self.config:
+            self._sync_runtime_variables()
 
     def get_cache_content(
         self: Self, relative_path: Path | str, revision_id: str

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -946,6 +946,32 @@ def test_fmu_directory_base_sync_runtime_variables(
     assert fmu_dir.cache.max_revisions == old_cache_max_revisions
 
 
+def test_restore_from_cache_syncs_runtime_variables(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests config restore updates runtime cache retention variables."""
+    current_config = fmu_dir.config.load()
+    original_cache_max_revisions = current_config.cache_max_revisions
+    restored_cache_max_revisions = original_cache_max_revisions + 1
+
+    updated_config = current_config.model_copy(
+        update={"cache_max_revisions": restored_cache_max_revisions}
+    )
+    revision_path = fmu_dir.cache.store_revision(
+        Path("config.json"),
+        updated_config.model_dump_json(by_alias=True, indent=2),
+    )
+    assert revision_path is not None
+
+    fmu_dir.restore_from_cache("config.json", revision_path.name)
+
+    assert fmu_dir.config.load(force=True).cache_max_revisions == (
+        restored_cache_max_revisions
+    )
+    assert fmu_dir.cache_max_revisions == restored_cache_max_revisions
+    assert fmu_dir.cache.max_revisions == restored_cache_max_revisions
+
+
 def test_fmu_directory_base_get_dir_diff_with_same_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,


### PR DESCRIPTION
Resolves #187 

Problem: restoring `config.json` from cache reloaded the config manager, but that did not update `cache_max_revisions` in the runtime cache manager. Thus, the restored config value could be correct on disk while the in-memory cache retention state still used the old value.

Solution: after restoring `config.json`, explicitly sync the runtime variables so the cache manager picks up the restored `cache_max_revisions`.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
