### PR TITLE
ENH: List restorable files before restoring from in-memory cache

### DIFF
--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -263,8 +263,23 @@ class FMUDirectoryBase:
         """
         return path_exists(self.get_file_path(relative_path))
 
-    def restore(self: Self) -> None:
+    def list_restorable_files(self: Self) -> list[Path]:
+        """List .fmu files that would be recreated by restore()."""
+        files: list[Path] = []
+
+        readme_path = self.get_file_path("README")
+        if self._README_CONTENT and not readme_path.exists():
+            files.append(Path("README"))
+
+        if not self.config.path.exists():
+            files.append(self.config.relative_path)
+
+        return files
+
+    def restore(self: Self) -> list[Path]:
         """Attempt to reconstruct missing .fmu files from in-memory state."""
+        restorable_files = self.list_restorable_files()
+
         if not path_exists(self.path):
             self.path.mkdir(parents=True, exist_ok=True)
             logger.info(f"Recreated missing .fmu directory at {self.path}")
@@ -283,6 +298,8 @@ class FMUDirectoryBase:
             else:
                 self.config.reset()
                 logger.info(f"Restored config.json from defaults at {config_path}")
+
+        return restorable_files
 
 
 class ProjectFMUDirectory(FMUDirectoryBase):
@@ -334,9 +351,22 @@ class ProjectFMUDirectory(FMUDirectoryBase):
         """Access the MappingsManager."""
         return self._mappings
 
-    def restore(self: Self) -> None:
+    def list_restorable_files(self: Self) -> list[Path]:
+        """List project .fmu files that would be recreated by restore()."""
+        files = super().list_restorable_files()
+
+        mappings_path = self.mappings.path
+        if (
+            not mappings_path.exists()
+            and getattr(self.mappings, "_cache", None) is not None
+        ):
+            files.append(self.mappings.relative_path)
+
+        return files
+
+    def restore(self: Self) -> list[Path]:
         """Attempt to reconstruct missing project .fmu files from in-memory state."""
-        super().restore()
+        restorable_files = super().restore()
 
         mappings_path = self.mappings.path
         if not path_exists(mappings_path):
@@ -346,6 +376,8 @@ class ProjectFMUDirectory(FMUDirectoryBase):
                 logger.info(
                     f"Restored mappings.json from cached model at {mappings_path}"
                 )
+
+        return restorable_files
 
     def update_config(self: Self, updates: dict[str, Any]) -> ProjectConfig:
         """Updates multiple configuration values at once.

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -627,9 +627,14 @@ def test_restore_rebuilds_project_fmu_from_cache(
     shutil.rmtree(fmu_dir.path)
     assert not fmu_dir.path.exists()
 
-    fmu_dir.restore()
+    restored_files = fmu_dir.restore()
 
     assert fmu_dir.path.exists()
+    assert restored_files == [
+        Path("README"),
+        Path("config.json"),
+        Path("mappings.json"),
+    ]
     readme_path = fmu_dir.path / "README"
     assert readme_path.exists()
     assert readme_path.read_text() == PROJECT_README_CONTENT
@@ -662,9 +667,10 @@ def test_restore_resets_when_cache_missing(
     with patch.object(
         fmu_dir.config, "reset", wraps=fmu_dir.config.reset
     ) as mock_reset:
-        fmu_dir.restore()
+        restored_files = fmu_dir.restore()
 
     mock_reset.assert_called_once()
+    assert restored_files == [Path("README"), Path("config.json")]
     assert fmu_dir.path.exists()
     readme_path = fmu_dir.path / "README"
     assert readme_path.exists()
@@ -679,9 +685,10 @@ def test_restore_rebuilds_user_fmu(user_fmu_dir: UserFMUDirectory) -> None:
     shutil.rmtree(user_fmu_dir.path)
     assert not user_fmu_dir.path.exists()
 
-    user_fmu_dir.restore()
+    restored_files = user_fmu_dir.restore()
 
     assert user_fmu_dir.path.exists()
+    assert restored_files == [Path("README"), Path("config.json")]
     readme_path = user_fmu_dir.path / "README"
     assert readme_path.exists()
     assert readme_path.read_text() == USER_README_CONTENT
@@ -691,6 +698,43 @@ def test_restore_rebuilds_user_fmu(user_fmu_dir: UserFMUDirectory) -> None:
     cached_dump.pop("last_modified_at", None)
     restored_dump.pop("last_modified_at", None)
     assert restored_dump == cached_dump
+
+
+def test_list_restorable_files_reports_missing_project_files(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests list_restorable_files reports only files restore would recreate."""
+    cached_mapping = StratigraphyIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=RelationType.primary,
+        source_id="TopVolantis",
+        target_id="VOLANTIS GP. Top",
+    )
+    fmu_dir.mappings.update_stratigraphy_mappings(
+        StratigraphyMappings(root=[cached_mapping])
+    )
+
+    (fmu_dir.path / "README").unlink()
+    fmu_dir.config.path.unlink()
+    fmu_dir.mappings.path.unlink()
+
+    assert fmu_dir.list_restorable_files() == [
+        Path("README"),
+        Path("config.json"),
+        Path("mappings.json"),
+    ]
+
+
+def test_list_restorable_files_skips_project_mappings_without_cache(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests list_restorable_files excludes mappings without cached content."""
+    fmu_dir.mappings._cache = None
+    if fmu_dir.mappings.path.exists():
+        fmu_dir.mappings.path.unlink()
+
+    assert fmu_dir.list_restorable_files() == []
 
 
 def test_fmu_directory_base_exposes_lock_timeout_kwarg() -> None:


### PR DESCRIPTION
Resolves #193 

Got feedback from joar in this [PR](https://github.com/equinor/fmu-settings-gui/pull/269#discussion_r2918795068) that it would be better if we list what files would be recreated/restored from memory before doing the restoration. If there's no file to restore, then the GUI will not show the "restore/recover" button.

Currently, the restore logic will only restore deleted files, but the restored files are not listed. This PR will add functionality to list those files, and there will be a follow up PR in the API after this is merged.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
