### PR TITLE
CI: Fix docs version shown on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv and set Python
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Resolves #222 

Currently https://equinor.github.io/fmu-settings/ shows the wrong version of fmu-settings because the workflow used a shallow checkout (only the commit that triggered the workflow). We should use `fetch-depth: 0` to fetch all history for all branches and tags to properly show the fmu-settings version in docs (ref [here](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4)).

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
