### PR TITLE
ENH: Add internal .fmu mappings models

### DIFF
--- a/src/fmu/settings/__init__.py
+++ b/src/fmu/settings/__init__.py
@@ -7,12 +7,39 @@ try:
 except ImportError:
     __version__ = version = "0.0.0"
 
-from ._fmu_dir import ProjectFMUDirectory, find_nearest_fmu_directory, get_fmu_directory
+from ._fmu_dir import (
+    ProjectFMUDirectory,
+    UserFMUDirectory,
+    find_nearest_fmu_directory,
+    get_fmu_directory,
+)
+from ._init import init_fmu_directory, init_user_fmu_directory
 from .models._enums import CacheResource
+from .models.mappings import (
+    InternalBaseMapping,
+    InternalIdentifierMapping,
+    InternalMappings,
+    InternalRelationType,
+    InternalStratigraphyIdentifierMapping,
+    InternalStratigraphyMappings,
+    InternalWellboreIdentifierMapping,
+    InternalWellboreMappings,
+)
 
 __all__ = [
     "CacheResource",
     "get_fmu_directory",
+    "init_fmu_directory",
+    "init_user_fmu_directory",
+    "InternalBaseMapping",
+    "InternalIdentifierMapping",
+    "InternalMappings",
+    "InternalRelationType",
+    "InternalStratigraphyIdentifierMapping",
+    "InternalStratigraphyMappings",
+    "InternalWellboreIdentifierMapping",
+    "InternalWellboreMappings",
     "ProjectFMUDirectory",
+    "UserFMUDirectory",
     "find_nearest_fmu_directory",
 ]

--- a/src/fmu/settings/__init__.py
+++ b/src/fmu/settings/__init__.py
@@ -13,7 +13,12 @@ from ._fmu_dir import (
     find_nearest_fmu_directory,
     get_fmu_directory,
 )
-from ._init import init_fmu_directory, init_user_fmu_directory
+from ._init import (
+    REQUIRED_FMU_PROJECT_SUBDIRS,
+    InvalidFMUProjectPathError,
+    init_fmu_directory,
+    init_user_fmu_directory,
+)
 from .models._enums import CacheResource
 from .models.mappings import (
     InternalBaseMapping,
@@ -39,7 +44,9 @@ __all__ = [
     "InternalStratigraphyMappings",
     "InternalWellboreIdentifierMapping",
     "InternalWellboreMappings",
+    "InvalidFMUProjectPathError",
     "ProjectFMUDirectory",
+    "REQUIRED_FMU_PROJECT_SUBDIRS",
     "UserFMUDirectory",
     "find_nearest_fmu_directory",
 ]

--- a/src/fmu/settings/_drogon/create.py
+++ b/src/fmu/settings/_drogon/create.py
@@ -5,10 +5,16 @@ if exposed from __init__.
 """
 
 from pathlib import Path
+from typing import Any
 
-from fmu.datamodels.context.mappings import StratigraphyMappings
+from fmu.datamodels.context.mappings import DataSystem, MappingType
 from fmu.settings import ProjectFMUDirectory
 from fmu.settings._init import init_fmu_directory
+from fmu.settings.models.mappings import (
+    FMURelationType,
+    FMUStratigraphyIdentifierMapping,
+    FMUStratigraphyMappings,
+)
 
 from ._data import PROJECT_CONFIG_DICT, STRATIGRAPHY_MAPPINGS
 
@@ -21,7 +27,62 @@ def create_drogon_fmu_dir(base_path: Path) -> ProjectFMUDirectory:
         force=True,
     )
 
-    stratigraphy_mappings = StratigraphyMappings.model_validate(STRATIGRAPHY_MAPPINGS)
-    fmu_dir._mappings.update_stratigraphy_mappings(stratigraphy_mappings)
+    stratigraphy_mappings = _build_fmu_stratigraphy_mappings(STRATIGRAPHY_MAPPINGS)
+    fmu_dir._mappings.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
 
     return fmu_dir
+
+
+def _build_fmu_stratigraphy_mappings(
+    mappings: list[dict[str, Any]],
+) -> FMUStratigraphyMappings:
+    """Build internal .fmu stratigraphy mappings from Drogon's STRATIGRAPHY_MAPPINGS."""
+    primary_source_by_target: dict[str, str] = {}
+    fmu_mappings: list[FMUStratigraphyIdentifierMapping] = []
+
+    for mapping in mappings:
+        if mapping["relation_type"] != "primary":
+            continue
+        primary_source_by_target[mapping["target_id"]] = mapping["source_id"]
+        fmu_mappings.append(
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem(mapping["source_system"]),
+                target_system=DataSystem(mapping["source_system"]),
+                mapping_type=MappingType.stratigraphy,
+                relation_type=FMURelationType.primary,
+                source_id=mapping["source_id"],
+                source_uuid=mapping.get("source_uuid"),
+                target_id=mapping["source_id"],
+                target_uuid=mapping.get("source_uuid"),
+            )
+        )
+        fmu_mappings.append(
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem(mapping["source_system"]),
+                target_system=DataSystem(mapping["target_system"]),
+                mapping_type=MappingType.stratigraphy,
+                relation_type=FMURelationType.primary,
+                source_id=mapping["source_id"],
+                source_uuid=mapping.get("source_uuid"),
+                target_id=mapping["target_id"],
+                target_uuid=mapping.get("target_uuid"),
+            )
+        )
+
+    for mapping in mappings:
+        if mapping["relation_type"] != "alias":
+            continue
+        fmu_mappings.append(
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem(mapping["source_system"]),
+                target_system=DataSystem(mapping["source_system"]),
+                mapping_type=MappingType.stratigraphy,
+                relation_type=FMURelationType.alias,
+                source_id=mapping["source_id"],
+                source_uuid=mapping.get("source_uuid"),
+                target_id=primary_source_by_target[mapping["target_id"]],
+                target_uuid=None,
+            )
+        )
+
+    return FMUStratigraphyMappings(root=fmu_mappings)

--- a/src/fmu/settings/_drogon/create.py
+++ b/src/fmu/settings/_drogon/create.py
@@ -11,9 +11,9 @@ from fmu.datamodels.context.mappings import DataSystem, MappingType
 from fmu.settings import ProjectFMUDirectory
 from fmu.settings._init import init_fmu_directory
 from fmu.settings.models.mappings import (
-    FMURelationType,
-    FMUStratigraphyIdentifierMapping,
-    FMUStratigraphyMappings,
+    InternalRelationType,
+    InternalStratigraphyIdentifierMapping,
+    InternalStratigraphyMappings,
 )
 
 from ._data import PROJECT_CONFIG_DICT, STRATIGRAPHY_MAPPINGS
@@ -27,41 +27,41 @@ def create_drogon_fmu_dir(base_path: Path) -> ProjectFMUDirectory:
         force=True,
     )
 
-    stratigraphy_mappings = _build_fmu_stratigraphy_mappings(STRATIGRAPHY_MAPPINGS)
-    fmu_dir._mappings.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    stratigraphy_mappings = _build_internal_stratigraphy_mappings(STRATIGRAPHY_MAPPINGS)
+    fmu_dir._mappings.update_internal_stratigraphy_mappings(stratigraphy_mappings)
 
     return fmu_dir
 
 
-def _build_fmu_stratigraphy_mappings(
+def _build_internal_stratigraphy_mappings(
     mappings: list[dict[str, Any]],
-) -> FMUStratigraphyMappings:
+) -> InternalStratigraphyMappings:
     """Build internal .fmu stratigraphy mappings from Drogon's STRATIGRAPHY_MAPPINGS."""
     primary_source_by_target: dict[str, str] = {}
-    fmu_mappings: list[FMUStratigraphyIdentifierMapping] = []
+    internal_mappings: list[InternalStratigraphyIdentifierMapping] = []
 
     for mapping in mappings:
         if mapping["relation_type"] != "primary":
             continue
         primary_source_by_target[mapping["target_id"]] = mapping["source_id"]
-        fmu_mappings.append(
-            FMUStratigraphyIdentifierMapping(
+        internal_mappings.append(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem(mapping["source_system"]),
                 target_system=DataSystem(mapping["source_system"]),
                 mapping_type=MappingType.stratigraphy,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=mapping["source_id"],
                 source_uuid=mapping.get("source_uuid"),
                 target_id=mapping["source_id"],
                 target_uuid=mapping.get("source_uuid"),
             )
         )
-        fmu_mappings.append(
-            FMUStratigraphyIdentifierMapping(
+        internal_mappings.append(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem(mapping["source_system"]),
                 target_system=DataSystem(mapping["target_system"]),
                 mapping_type=MappingType.stratigraphy,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=mapping["source_id"],
                 source_uuid=mapping.get("source_uuid"),
                 target_id=mapping["target_id"],
@@ -72,12 +72,12 @@ def _build_fmu_stratigraphy_mappings(
     for mapping in mappings:
         if mapping["relation_type"] != "alias":
             continue
-        fmu_mappings.append(
-            FMUStratigraphyIdentifierMapping(
+        internal_mappings.append(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem(mapping["source_system"]),
                 target_system=DataSystem(mapping["source_system"]),
                 mapping_type=MappingType.stratigraphy,
-                relation_type=FMURelationType.alias,
+                relation_type=InternalRelationType.alias,
                 source_id=mapping["source_id"],
                 source_uuid=mapping.get("source_uuid"),
                 target_id=primary_source_by_target[mapping["target_id"]],
@@ -85,4 +85,4 @@ def _build_fmu_stratigraphy_mappings(
             )
         )
 
-    return FMUStratigraphyMappings(root=fmu_mappings)
+    return InternalStratigraphyMappings(root=internal_mappings)

--- a/src/fmu/settings/_resources/mappings_manager.py
+++ b/src/fmu/settings/_resources/mappings_manager.py
@@ -4,26 +4,34 @@ import copy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
+from fmu.datamodels.context.mappings import (
+    RelationType,
+    StratigraphyMappings,
+    WellboreMappings,
+)
 from fmu.datamodels.fmu_results.global_configuration import Stratigraphy
 from fmu.settings._resources.pydantic_resource_manager import PydanticResourceManager
-from fmu.settings.models.mappings import Mappings, RelationType
+from fmu.settings.models.mappings import (
+    FMUMappings,
+    FMUStratigraphyMappings,
+    FMUWellboreMappings,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     # Avoid circular dependency for type hint in __init__ only
-    from fmu.datamodels.context.mappings import StratigraphyMappings, WellboreMappings
     from fmu.settings._fmu_dir import ProjectFMUDirectory
 
 
-class MappingsManager(PydanticResourceManager[Mappings]):
+class MappingsManager(PydanticResourceManager[FMUMappings]):
     """Manages the .fmu mappings file."""
 
     fmu_dir: ProjectFMUDirectory
 
     def __init__(self: Self, fmu_dir: ProjectFMUDirectory) -> None:
         """Initializes the mappings resource manager."""
-        super().__init__(fmu_dir, Mappings)
+        super().__init__(fmu_dir, FMUMappings)
 
     @property
     def relative_path(self: Self) -> Path:
@@ -39,20 +47,30 @@ class MappingsManager(PydanticResourceManager[Mappings]):
         }
 
     @property
-    def stratigraphy_mappings(self: Self) -> StratigraphyMappings:
-        """Get all stratigraphy mappings."""
+    def fmu_stratigraphy_mappings(self: Self) -> FMUStratigraphyMappings:
+        """Get internal .fmu stratigraphy mappings."""
         return self.load().stratigraphy
 
     @property
-    def wellbore_mappings(self: Self) -> WellboreMappings:
-        """Get all wellbore mappings."""
+    def fmu_wellbore_mappings(self: Self) -> FMUWellboreMappings:
+        """Get internal .fmu wellbore mappings."""
         return self.load().wellbore
 
-    def update_stratigraphy_mappings(
-        self: Self, strat_mappings: StratigraphyMappings
-    ) -> StratigraphyMappings:
-        """Updates the stratigraphy mappings in the mappings resource."""
-        mappings: Mappings = self.load() if self.exists else Mappings()
+    @property
+    def stratigraphy_mappings(self: Self) -> StratigraphyMappings:
+        """Get stratigraphy mappings as a fmu-datamodels StratigraphyMappings."""
+        return self.fmu_stratigraphy_mappings.to_stratigraphy_mappings()
+
+    @property
+    def wellbore_mappings(self: Self) -> WellboreMappings:
+        """Get wellbore mappings as a fmu-datamodels WellboreMappings."""
+        return self.fmu_wellbore_mappings.to_wellbore_mappings()
+
+    def update_fmu_stratigraphy_mappings(
+        self: Self, strat_mappings: FMUStratigraphyMappings
+    ) -> FMUStratigraphyMappings:
+        """Updates the internal .fmu stratigraphy mappings resource."""
+        mappings: FMUMappings = self.load() if self.exists else FMUMappings()
 
         old_mappings_dict = copy.deepcopy(mappings.model_dump())
         mappings.stratigraphy = strat_mappings
@@ -64,13 +82,13 @@ class MappingsManager(PydanticResourceManager[Mappings]):
             relative_path=self.relative_path,
         )
 
-        return self.stratigraphy_mappings
+        return self.fmu_stratigraphy_mappings
 
-    def update_wellbore_mappings(
-        self: Self, wellbore_mappings: WellboreMappings
-    ) -> WellboreMappings:
-        """Updates the wellbore mappings in the mappings resource."""
-        mappings: Mappings = self.load() if self.exists else Mappings()
+    def update_fmu_wellbore_mappings(
+        self: Self, wellbore_mappings: FMUWellboreMappings
+    ) -> FMUWellboreMappings:
+        """Updates the internal .fmu wellbore mappings resource."""
+        mappings: FMUMappings = self.load() if self.exists else FMUMappings()
 
         old_mappings_dict = copy.deepcopy(mappings.model_dump())
         mappings.wellbore = wellbore_mappings
@@ -82,9 +100,11 @@ class MappingsManager(PydanticResourceManager[Mappings]):
             relative_path=self.relative_path,
         )
 
-        return self.wellbore_mappings
+        return self.fmu_wellbore_mappings
 
-    def get_mappings_diff(self: Self, incoming_mappings: MappingsManager) -> Mappings:
+    def get_mappings_diff(
+        self: Self, incoming_mappings: MappingsManager
+    ) -> FMUMappings:
         """Get mappings diff with the incoming mappings resource.
 
         All mappings from the incoming mappings resource are returned.
@@ -97,7 +117,7 @@ class MappingsManager(PydanticResourceManager[Mappings]):
             f"Incoming mappings resource exists: {incoming_mappings.exists}."
         )
 
-    def merge_mappings(self: Self, incoming_mappings: MappingsManager) -> Mappings:
+    def merge_mappings(self: Self, incoming_mappings: MappingsManager) -> FMUMappings:
         """Merge the mappings from the incoming mappings resource.
 
         The current mappings will be updated with the mappings
@@ -106,32 +126,35 @@ class MappingsManager(PydanticResourceManager[Mappings]):
         mappings_diff = self.get_mappings_diff(incoming_mappings)
         return self.merge_changes(mappings_diff)
 
-    def merge_changes(self: Self, changes: Mappings) -> Mappings:
+    def merge_changes(self: Self, changes: FMUMappings) -> FMUMappings:
         """Merge the mappings changes into the current mappings.
 
         The current mappings will be updated with the mappings
         in the change object.
         """
-        if len(changes.stratigraphy) > 0 or len(self.stratigraphy_mappings) > 0:
-            self.update_stratigraphy_mappings(changes.stratigraphy)
-        if len(changes.wellbore) > 0 or len(self.wellbore_mappings) > 0:
-            self.update_wellbore_mappings(changes.wellbore)
+        if len(changes.stratigraphy) > 0 or len(self.fmu_stratigraphy_mappings) > 0:
+            self.update_fmu_stratigraphy_mappings(changes.stratigraphy)
+        if len(changes.wellbore) > 0 or len(self.fmu_wellbore_mappings) > 0:
+            self.update_fmu_wellbore_mappings(changes.wellbore)
         return self.load()
 
-    def build_global_config_stratigraphy(self) -> Stratigraphy:  # noqa: PLR0912
+    def build_global_config_stratigraphy(self) -> Stratigraphy:
         """Build a global config stratigraphy from mappings and RMS config.
 
-        Combines stratigraphy mappings with RMS horizons and zones from the project
-        config to produce a stratigraphy suitable for a GlobalConfiguration.
+        Combines the fmu-datamodels stratigraphy mappings with RMS horizons
+        and zones from the project config to produce a stratigraphy suitable for a
+        GlobalConfiguration.
         """
         stratigraphy: dict[str, dict[str, Any]] = {}
-        mappings = self.load() if self.exists else Mappings()
+        stratigraphy_mappings = (
+            self.stratigraphy_mappings if self.exists else StratigraphyMappings(root=[])
+        )
 
         primaries: dict[str, str] = {}  # source_id -> target_id
         aliases_by_target: dict[str, list[str]] = {}  # target_id -> [alias source_ids]
 
         # Stratigraphic entries from stratigraphy mappings
-        for mapping in mappings.stratigraphy:
+        for mapping in stratigraphy_mappings:
             if mapping.relation_type == RelationType.primary:
                 primaries[mapping.source_id] = mapping.target_id
             elif mapping.relation_type == RelationType.alias:

--- a/src/fmu/settings/_resources/mappings_manager.py
+++ b/src/fmu/settings/_resources/mappings_manager.py
@@ -12,9 +12,9 @@ from fmu.datamodels.context.mappings import (
 from fmu.datamodels.fmu_results.global_configuration import Stratigraphy
 from fmu.settings._resources.pydantic_resource_manager import PydanticResourceManager
 from fmu.settings.models.mappings import (
-    FMUMappings,
-    FMUStratigraphyMappings,
-    FMUWellboreMappings,
+    InternalMappings,
+    InternalStratigraphyMappings,
+    InternalWellboreMappings,
 )
 
 if TYPE_CHECKING:
@@ -24,14 +24,14 @@ if TYPE_CHECKING:
     from fmu.settings._fmu_dir import ProjectFMUDirectory
 
 
-class MappingsManager(PydanticResourceManager[FMUMappings]):
+class MappingsManager(PydanticResourceManager[InternalMappings]):
     """Manages the .fmu mappings file."""
 
     fmu_dir: ProjectFMUDirectory
 
     def __init__(self: Self, fmu_dir: ProjectFMUDirectory) -> None:
         """Initializes the mappings resource manager."""
-        super().__init__(fmu_dir, FMUMappings)
+        super().__init__(fmu_dir, InternalMappings)
 
     @property
     def relative_path(self: Self) -> Path:
@@ -47,30 +47,30 @@ class MappingsManager(PydanticResourceManager[FMUMappings]):
         }
 
     @property
-    def fmu_stratigraphy_mappings(self: Self) -> FMUStratigraphyMappings:
-        """Get internal .fmu stratigraphy mappings."""
+    def internal_stratigraphy_mappings(self: Self) -> InternalStratigraphyMappings:
+        """Get stratigraphy mappings stored in the internal .fmu mappings format."""
         return self.load().stratigraphy
 
     @property
-    def fmu_wellbore_mappings(self: Self) -> FMUWellboreMappings:
-        """Get internal .fmu wellbore mappings."""
+    def internal_wellbore_mappings(self: Self) -> InternalWellboreMappings:
+        """Get wellbore mappings stored in the internal .fmu mappings format."""
         return self.load().wellbore
 
     @property
     def stratigraphy_mappings(self: Self) -> StratigraphyMappings:
-        """Get stratigraphy mappings as a fmu-datamodels StratigraphyMappings."""
-        return self.fmu_stratigraphy_mappings.to_stratigraphy_mappings()
+        """Get stratigraphy mappings as fmu-datamodels StratigraphyMappings."""
+        return self.internal_stratigraphy_mappings.to_stratigraphy_mappings()
 
     @property
     def wellbore_mappings(self: Self) -> WellboreMappings:
-        """Get wellbore mappings as a fmu-datamodels WellboreMappings."""
-        return self.fmu_wellbore_mappings.to_wellbore_mappings()
+        """Get wellbore mappings as fmu-datamodels WellboreMappings."""
+        return self.internal_wellbore_mappings.to_wellbore_mappings()
 
-    def update_fmu_stratigraphy_mappings(
-        self: Self, strat_mappings: FMUStratigraphyMappings
-    ) -> FMUStratigraphyMappings:
-        """Updates the internal .fmu stratigraphy mappings resource."""
-        mappings: FMUMappings = self.load() if self.exists else FMUMappings()
+    def update_internal_stratigraphy_mappings(
+        self: Self, strat_mappings: InternalStratigraphyMappings
+    ) -> InternalStratigraphyMappings:
+        """Update stratigraphy mappings stored in the internal .fmu mappings format."""
+        mappings: InternalMappings = self.load() if self.exists else InternalMappings()
 
         old_mappings_dict = copy.deepcopy(mappings.model_dump())
         mappings.stratigraphy = strat_mappings
@@ -82,13 +82,13 @@ class MappingsManager(PydanticResourceManager[FMUMappings]):
             relative_path=self.relative_path,
         )
 
-        return self.fmu_stratigraphy_mappings
+        return self.internal_stratigraphy_mappings
 
-    def update_fmu_wellbore_mappings(
-        self: Self, wellbore_mappings: FMUWellboreMappings
-    ) -> FMUWellboreMappings:
-        """Updates the internal .fmu wellbore mappings resource."""
-        mappings: FMUMappings = self.load() if self.exists else FMUMappings()
+    def update_internal_wellbore_mappings(
+        self: Self, wellbore_mappings: InternalWellboreMappings
+    ) -> InternalWellboreMappings:
+        """Update wellbore mappings stored in the internal .fmu mappings format."""
+        mappings: InternalMappings = self.load() if self.exists else InternalMappings()
 
         old_mappings_dict = copy.deepcopy(mappings.model_dump())
         mappings.wellbore = wellbore_mappings
@@ -100,11 +100,11 @@ class MappingsManager(PydanticResourceManager[FMUMappings]):
             relative_path=self.relative_path,
         )
 
-        return self.fmu_wellbore_mappings
+        return self.internal_wellbore_mappings
 
     def get_mappings_diff(
         self: Self, incoming_mappings: MappingsManager
-    ) -> FMUMappings:
+    ) -> InternalMappings:
         """Get mappings diff with the incoming mappings resource.
 
         All mappings from the incoming mappings resource are returned.
@@ -117,7 +117,9 @@ class MappingsManager(PydanticResourceManager[FMUMappings]):
             f"Incoming mappings resource exists: {incoming_mappings.exists}."
         )
 
-    def merge_mappings(self: Self, incoming_mappings: MappingsManager) -> FMUMappings:
+    def merge_mappings(
+        self: Self, incoming_mappings: MappingsManager
+    ) -> InternalMappings:
         """Merge the mappings from the incoming mappings resource.
 
         The current mappings will be updated with the mappings
@@ -126,16 +128,19 @@ class MappingsManager(PydanticResourceManager[FMUMappings]):
         mappings_diff = self.get_mappings_diff(incoming_mappings)
         return self.merge_changes(mappings_diff)
 
-    def merge_changes(self: Self, changes: FMUMappings) -> FMUMappings:
+    def merge_changes(self: Self, changes: InternalMappings) -> InternalMappings:
         """Merge the mappings changes into the current mappings.
 
         The current mappings will be updated with the mappings
         in the change object.
         """
-        if len(changes.stratigraphy) > 0 or len(self.fmu_stratigraphy_mappings) > 0:
-            self.update_fmu_stratigraphy_mappings(changes.stratigraphy)
-        if len(changes.wellbore) > 0 or len(self.fmu_wellbore_mappings) > 0:
-            self.update_fmu_wellbore_mappings(changes.wellbore)
+        if (
+            len(changes.stratigraphy) > 0
+            or len(self.internal_stratigraphy_mappings) > 0
+        ):
+            self.update_internal_stratigraphy_mappings(changes.stratigraphy)
+        if len(changes.wellbore) > 0 or len(self.internal_wellbore_mappings) > 0:
+            self.update_internal_wellbore_mappings(changes.wellbore)
         return self.load()
 
     def build_global_config_stratigraphy(self) -> Stratigraphy:

--- a/src/fmu/settings/models/_enums.py
+++ b/src/fmu/settings/models/_enums.py
@@ -3,37 +3,6 @@
 from enum import StrEnum
 
 
-class MappingType(StrEnum):
-    """The discriminator used between mappings.
-
-    Each of these types should have their own mapping class derived of some sort of
-    mapping.
-    """
-
-    fault = "fault"
-    stratigraphy = "stratigraphy"
-    well = "well"
-
-
-class RelationType(StrEnum):
-    """The kind of relation this mapping represents."""
-
-    alias = "alias"
-    child_to_parent = "child_to_parent"
-    equivalent = "equivalent"
-    fmu_to_target = "fmu_to_target"
-    predecessor_to_successor = "predecessor_to_successor"
-
-
-class DataEntrySource(StrEnum):
-    user = "user"
-    automated = "automated"
-
-
-class TargetSystem(StrEnum):
-    smda = "smda"
-
-
 class ChangeType(StrEnum):
     """The types of change that can be made on a file."""
 

--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -1,163 +1,447 @@
-"""Model for the mappings.json file."""
+"""Models for the mappings.json file."""
 
-from typing import Any, Self
+from collections.abc import Iterator, Sequence
+from enum import StrEnum
+from typing import Any, Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_serializer, model_validator
+from pydantic import BaseModel, Field, RootModel, field_validator, model_validator
 
 from fmu.datamodels.context.mappings import (
-    AnyIdentifierMapping,
     DataSystem,
     MappingType,
     RelationType,
+    StratigraphyIdentifierMapping,
     StratigraphyMappings,
+    WellboreIdentifierMapping,
     WellboreMappings,
 )
 
 
-class Mappings(BaseModel):
+class FMURelationType(StrEnum):
+    """The kind of relation a .fmu mapping represents."""
+
+    primary = "primary"
+    """The main source identifier to use for this mapping."""
+
+    alias = "alias"
+    """Alias of a primary identifier."""
+
+    unmappable = "unmappable"
+    """A source identifier that has been reviewed and cannot be mapped."""
+
+
+class FMUBaseMapping(BaseModel):
+    """Base mapping fields stored in a .fmu mappings file."""
+
+    source_system: DataSystem
+    target_system: DataSystem
+    mapping_type: MappingType
+    relation_type: FMURelationType
+
+    @model_validator(mode="after")
+    def validate_relation_system_constraints(self: Self) -> Self:
+        """Validate which relation types are allowed for same vs cross-system mappings.
+
+        Same-system mappings can only be ``primary`` or ``alias``.
+        Cross-system mappings can only be ``primary`` or ``unmappable``.
+        """
+        if self.source_system == self.target_system:
+            if self.relation_type == FMURelationType.unmappable:
+                raise ValueError(
+                    "Same-system mapping cannot use relation_type 'unmappable'"
+                )
+            return self
+
+        if self.relation_type == FMURelationType.alias:
+            raise ValueError("Cross-system mapping cannot use relation_type 'alias'")
+
+        return self
+
+
+class FMUIdentifierMapping(FMUBaseMapping):
+    """Identifier mapping stored in a .fmu mappings file."""
+
+    source_id: str
+    source_uuid: UUID | None = None
+    target_id: str | None = None
+    target_uuid: UUID | None = None
+
+    @field_validator("source_id")
+    @classmethod
+    def validate_source_id_not_empty(cls, value: str) -> str:
+        """Ensure source identifiers are not empty strings."""
+        if not value or not value.strip():
+            raise ValueError("An identifier cannot be an empty string")
+        return value.strip()
+
+    @field_validator("target_id")
+    @classmethod
+    def validate_target_id_not_empty(cls, value: str | None) -> str | None:
+        """Ensure target identifiers are not empty strings when provided."""
+        if value is None:
+            return value
+        if not value.strip():
+            raise ValueError("An identifier cannot be an empty string")
+        return value.strip()
+
+    @model_validator(mode="after")
+    def validate_relation_target_constraints(self: Self) -> Self:
+        """Validate how ``source_id`` and ``target_id`` are allowed to relate.
+
+        This means:
+        - ``unmappable`` mappings must leave the target empty
+        - all other mappings must provide a target
+        - same-system ``primary`` mappings must use the same ``source_id`` and
+          ``target_id``
+        - same-system ``alias`` mappings must point to a different same-system
+          ``target_id``
+        """
+        if self.relation_type == FMURelationType.unmappable:
+            if self.target_id is not None or self.target_uuid is not None:
+                raise ValueError(
+                    "Unmappable mapping cannot define target_id or target_uuid"
+                )
+            return self
+
+        if self.target_id is None:
+            raise ValueError(
+                "target_id is required unless relation_type is 'unmappable'"
+            )
+
+        if self.source_system == self.target_system:
+            if self.relation_type == FMURelationType.primary:
+                if self.source_id != self.target_id:
+                    raise ValueError(
+                        "Same-system primary mapping must have matching source_id "
+                        "and target_id; use relation_type='alias' if they should "
+                        "differ"
+                    )
+                return self
+
+            if self.relation_type == FMURelationType.alias:
+                if self.source_id == self.target_id:
+                    raise ValueError(
+                        "Same-system alias mapping must have different source_id "
+                        "and target_id; use relation_type='primary' if they should "
+                        "match"
+                    )
+                return self
+
+        return self
+
+
+class FMUStratigraphyIdentifierMapping(FMUIdentifierMapping):
+    """Stratigraphy identifier mapping stored in a .fmu mappings file."""
+
+    mapping_type: Literal[MappingType.stratigraphy] = MappingType.stratigraphy
+
+
+class FMUWellboreIdentifierMapping(FMUIdentifierMapping):
+    """Wellbore identifier mapping stored in a .fmu mappings file."""
+
+    mapping_type: Literal[MappingType.wellbore] = MappingType.wellbore
+
+
+class FMUStratigraphyMappings(RootModel[list[FMUStratigraphyIdentifierMapping]]):
+    """Collection of stratigraphy mappings stored in a .fmu mappings file."""
+
+    root: list[FMUStratigraphyIdentifierMapping]
+
+    @model_validator(mode="after")
+    def validate_collection(self: Self) -> Self:
+        """Ensure the mapping collection follows the allowed mapping rules."""
+        _validate_identifier_mappings_collection(self.root)
+        return self
+
+    def to_stratigraphy_mappings(self: Self) -> StratigraphyMappings:
+        """Convert internal .fmu mappings to fmu-datamodels StratigraphyMappings."""
+        return StratigraphyMappings(
+            root=[
+                StratigraphyIdentifierMapping(**mapping)
+                for mapping in _get_identifier_mapping_payloads(self.root)
+            ]
+        )
+
+    def __getitem__(self: Self, index: int) -> FMUStratigraphyIdentifierMapping:
+        """Retrieve a stratigraphy mapping from the list by index."""
+        return self.root[index]
+
+    def __iter__(self: Self) -> Iterator[FMUStratigraphyIdentifierMapping]:  # type: ignore[override]
+        """Return an iterator for the stratigraphy mappings."""
+        return iter(self.root)
+
+    def __len__(self: Self) -> int:
+        """Return the number of stratigraphy mappings."""
+        return len(self.root)
+
+
+class FMUWellboreMappings(RootModel[list[FMUWellboreIdentifierMapping]]):
+    """Collection of wellbore mappings stored in a .fmu mappings file."""
+
+    root: list[FMUWellboreIdentifierMapping]
+
+    @model_validator(mode="after")
+    def validate_collection(self: Self) -> Self:
+        """Ensure the mapping collection follows the allowed mapping rules."""
+        _validate_identifier_mappings_collection(self.root)
+        return self
+
+    def to_wellbore_mappings(self: Self) -> WellboreMappings:
+        """Convert internal .fmu mappings to fmu-datamodels WellboreMappings."""
+        return WellboreMappings(
+            root=[
+                WellboreIdentifierMapping(**mapping)
+                for mapping in _get_identifier_mapping_payloads(self.root)
+            ]
+        )
+
+    def __getitem__(self: Self, index: int) -> FMUWellboreIdentifierMapping:
+        """Retrieve a wellbore mapping from the list by index."""
+        return self.root[index]
+
+    def __iter__(self: Self) -> Iterator[FMUWellboreIdentifierMapping]:  # type: ignore[override]
+        """Return an iterator for the wellbore mappings."""
+        return iter(self.root)
+
+    def __len__(self: Self) -> int:
+        """Return the number of wellbore mappings."""
+        return len(self.root)
+
+
+class FMUMappings(BaseModel):
     """Represents the mappings file in a .fmu directory."""
 
-    stratigraphy: StratigraphyMappings = Field(
-        default_factory=lambda: StratigraphyMappings(root=[])
+    stratigraphy: FMUStratigraphyMappings = Field(
+        default_factory=lambda: FMUStratigraphyMappings(root=[])
     )
     """Stratigraphy mappings in the mappings file."""
 
-    wellbore: WellboreMappings = Field(
-        default_factory=lambda: WellboreMappings(root=[])
+    wellbore: FMUWellboreMappings = Field(
+        default_factory=lambda: FMUWellboreMappings(root=[])
     )
     """Wellbore mappings in the mappings file."""
 
 
-class MappingGroup(BaseModel):
-    """A mapping group containing related mappings with a shared target context.
+def _validate_identifier_mappings_collection(
+    mappings: Sequence[FMUIdentifierMapping],
+) -> None:
+    """Validate how mappings are allowed to fit together.
 
-    This is a view of the data for GUI display purposes, not how it's stored.
-    Groups mappings that share target_id, target_uuid (if set), mapping_type,
-    target_system, and source_system.
+    The collection must satisfy three invariants:
+
+    - A same-system ``source_id`` can appear only once per mapping type.
+      Example valid mappings::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+
+      Example invalid mappings::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> rms, alias, source_id="TopVolantis", target_id="TopVolon"
+
+      The second mapping is invalid because ``TopVolantis`` is reused as a
+      same-system ``source_id``.
+
+    - Same-system alias mappings must point to an existing same-system primary
+      mapping.
+      Example valid mappings::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+
+      Example invalid mapping::
+
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+
+      The alias is invalid on its own because there is no same-system primary
+      mapping for ``TopVolantis``.
+
+    - Cross-system mappings must originate from a same-system primary mapping and
+      can appear only once per target system.
+      Example valid mappings::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> smda, primary, source_id="TopVolantis", target_id="VOLANTIS GP. Top"
+
+      Example invalid mappings::
+
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+          rms -> smda, primary, source_id="TOP_VOLANTIS", target_id="VOLANTIS GP. Top"
+
+      The cross-system mapping is invalid because it starts from an alias instead
+      of a same-system primary. It is also invalid to add two ``rms -> smda``
+      mappings for the same ``source_id``.
     """
+    same_system_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
+    same_system_primary_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
+    same_system_aliases: list[FMUIdentifierMapping] = []
+    cross_system_source_keys: set[tuple[MappingType, DataSystem, DataSystem, str]] = (
+        set()
+    )
+    cross_system_mappings: list[FMUIdentifierMapping] = []
 
-    target_id: str
-    target_uuid: UUID | None = None
-    mapping_type: MappingType
-    target_system: DataSystem
-    source_system: DataSystem
-    mappings: list[AnyIdentifierMapping]
-
-    def _count_mappings_by_relation_type(
-        self: Self, relation_type: RelationType
-    ) -> int:
-        return sum(
-            1 for mapping in self.mappings if mapping.relation_type == relation_type
+    for mapping in mappings:
+        source_key = (
+            mapping.source_system,
+            mapping.mapping_type,
+            mapping.source_id,
         )
 
-    @model_validator(mode="after")
-    def validate_group(self) -> "MappingGroup":
-        """Ensure MappingGroup contains a valid combination of mappings.
+        # Same-system mappings tell us which source_id is the primary and which
+        # source_ids are aliases of that primary.
+        if mapping.source_system == mapping.target_system:
+            if source_key in same_system_source_keys:
+                raise ValueError("Same-system mappings cannot reuse the same source_id")
+            same_system_source_keys.add(source_key)
 
-        Validates that:
-        - At most one primary mapping per mapping group
-        - Mapping group with alias mapping(s) requires a primary mapping
-        - No duplicate mappings in a mappping group
-        - All mappings in a mapping group share the same target_id, mapping_type,
-          target_system and source_system
+            if mapping.relation_type == FMURelationType.primary:
+                same_system_primary_source_keys.add(source_key)
+            else:
+                same_system_aliases.append(mapping)
+            continue
 
-        Raises:
-            ValueError: If validation fails or mapping type is unsupported
-        """
-        if not self.mappings:
-            return self
-
-        primary_mappings_count = self._count_mappings_by_relation_type(
-            RelationType.primary
+        # A source_id can map to each target system only once.
+        cross_system_key = (
+            mapping.mapping_type,
+            mapping.source_system,
+            mapping.target_system,
+            mapping.source_id,
         )
-        has_alias_mapping = (
-            self._count_mappings_by_relation_type(RelationType.alias) > 0
-        )
-
-        if primary_mappings_count > 1:
+        if cross_system_key in cross_system_source_keys:
             raise ValueError(
-                f"MappingGroup for target '{self.target_id}' must contain at most one "
-                "primary mapping."
+                "A source_id can only have one cross-system mapping per target system"
             )
+        cross_system_source_keys.add(cross_system_key)
+        cross_system_mappings.append(mapping)
 
-        if has_alias_mapping and primary_mappings_count == 0:
+    # Every alias must point to a same-system primary source_id that already
+    # exists in the collection.
+    for mapping in same_system_aliases:
+        primary_target_id = mapping.target_id
+        assert primary_target_id is not None
+        primary_target_key = (
+            mapping.source_system,
+            mapping.mapping_type,
+            primary_target_id,
+        )
+        if primary_target_key not in same_system_primary_source_keys:
             raise ValueError(
-                f"MappingGroup for target '{self.target_id}' contains "
-                "alias relations but no primary relation. Aliases require "
-                "a primary unofficial identifier."
+                "Same-system alias mappings must point to an existing "
+                "same-system primary source_id"
             )
 
-        seen: set[tuple[str, UUID | None, RelationType]] = set()
-        for mapping in self.mappings:
-            mapping_key = (
-                mapping.source_id,
-                mapping.source_uuid,
-                mapping.relation_type,
+    # Cross-system mappings are only allowed when they start from a same-system
+    # primary source_id.
+    for mapping in cross_system_mappings:
+        primary_source_key = (
+            mapping.source_system,
+            mapping.mapping_type,
+            mapping.source_id,
+        )
+        if primary_source_key not in same_system_primary_source_keys:
+            raise ValueError(
+                "Cross-system mappings must use a source_id that is defined "
+                "as a same-system primary"
             )
-            if mapping_key in seen:
-                raise ValueError(
-                    f"Duplicate mapping in group: source_id='{mapping.source_id}', "
-                    f"source_uuid='{mapping.source_uuid}', "
-                    f"relation_type='{mapping.relation_type}'."
-                )
 
-            if mapping.target_id != self.target_id:
-                raise ValueError(
-                    "All mappings in MappingGroup must share target_id "
-                    f"'{self.target_id}'."
-                )
-            if mapping.mapping_type != self.mapping_type:
-                raise ValueError(
-                    "All mappings in MappingGroup must share mapping_type "
-                    f"'{self.mapping_type}'."
-                )
-            if mapping.target_system != self.target_system:
-                raise ValueError(
-                    "All mappings in MappingGroup must share target_system "
-                    f"'{self.target_system}'."
-                )
-            if mapping.source_system != self.source_system:
-                raise ValueError(
-                    "All mappings in MappingGroup must share source_system "
-                    f"'{self.source_system}'."
-                )
-            if (
-                mapping.target_uuid is not None
-                and self.target_uuid is not None
-                and mapping.target_uuid != self.target_uuid
-            ):
-                raise ValueError(
-                    "All mappings in MappingGroup must share target_uuid "
-                    f"'{self.target_uuid}'."
-                )
 
-            seen.add(mapping_key)
+def _get_identifier_mapping_payloads(
+    mappings: Sequence[FMUIdentifierMapping],
+) -> list[dict[str, Any]]:
+    """Return payloads for the identifier mapping models from fmu-datamodels.
 
-        return self
+    Stored .fmu mappings can describe relationships inside the same system, for
+    example ``rms -> rms`` primaries and aliases. Downstream consumers often need
+    the regular mapping models from fmu-datamodels instead, for example
+    ``rms -> smda``.
 
-    @model_serializer(mode="plain")
-    def serialize_for_display(self) -> dict[str, Any]:
-        """Serialize to the display schema for API responses."""
-        excluded_fields = {
-            "source_system",
-            "target_system",
-            "mapping_type",
-            "target_id",
-            "target_uuid",
-        }
-        return {
-            "official_name": self.target_id,
-            "target_uuid": self.target_uuid,
-            "mapping_type": self.mapping_type.value,
-            "target_system": self.target_system.value,
-            "source_system": self.source_system.value,
-            "mappings": [
+    This method first finds same-system aliases and groups them by the same-system
+    primary identifier they point to. It then keeps cross-system primary mappings
+    and adds matching aliases to the same cross-system target. A same-system alias
+    is only included when its primary identifier also has a cross-system primary
+    mapping.
+
+    Example:
+    - ``rms -> rms: TopVolantis primary TopVolantis``
+    - ``rms -> rms: TopVOLANTIS alias TopVolantis``
+    - ``rms -> rms: TOP_VOLANTIS alias TopVolantis``
+    - ``rms -> smda: TopVolantis primary VOLANTIS GP. Top``
+    - ``rms -> rms: Seabase primary Seabase``
+    - ``rms -> smda: Seabase unmappable``
+
+    becomes:
+    - ``rms -> smda: TopVolantis primary VOLANTIS GP. Top``
+    - ``rms -> smda: TopVOLANTIS alias VOLANTIS GP. Top``
+    - ``rms -> smda: TOP_VOLANTIS alias VOLANTIS GP. Top``
+
+    Same-system mappings and unmappable mappings are not included in the returned
+    fmu-datamodels mapping payloads.
+    """
+    aliases_by_primary: dict[
+        tuple[MappingType, DataSystem, str], list[FMUIdentifierMapping]
+    ] = {}
+
+    # Group same-system aliases by the same-system primary id they point to.
+    for mapping in mappings:
+        if _is_same_system_alias(mapping):
+            assert mapping.target_id is not None
+            aliases_by_primary.setdefault(
+                _primary_key(mapping, mapping.target_id), []
+            ).append(mapping)
+
+    mapping_payloads: list[dict[str, Any]] = []
+
+    # Keep cross-system primaries and add matching aliases to the same target.
+    for mapping in mappings:
+        if not _is_cross_system_primary(mapping):
+            continue
+
+        mapping_payloads.append(_to_mapping_payload(mapping))
+        for alias_mapping in aliases_by_primary.get(
+            _primary_key(mapping, mapping.source_id), []
+        ):
+            alias_payload = _to_mapping_payload(mapping)
+            alias_payload.update(
                 {
-                    key: value
-                    for key, value in mapping.model_dump().items()
-                    if key not in excluded_fields
+                    "relation_type": RelationType.alias,
+                    "source_id": alias_mapping.source_id,
+                    "source_uuid": alias_mapping.source_uuid,
                 }
-                for mapping in self.mappings
-            ],
-        }
+            )
+            mapping_payloads.append(alias_payload)
+
+    return mapping_payloads
+
+
+def _is_same_system_alias(mapping: FMUIdentifierMapping) -> bool:
+    """Return whether a mapping is a same-system alias."""
+    return (
+        mapping.source_system == mapping.target_system
+        and mapping.relation_type == FMURelationType.alias
+        and mapping.target_id is not None
+    )
+
+
+def _is_cross_system_primary(mapping: FMUIdentifierMapping) -> bool:
+    """Return whether a mapping is a cross-system primary with a target."""
+    return (
+        mapping.source_system != mapping.target_system
+        and mapping.relation_type == FMURelationType.primary
+        and mapping.target_id is not None
+    )
+
+
+def _primary_key(
+    mapping: FMUIdentifierMapping, source_id: str
+) -> tuple[MappingType, DataSystem, str]:
+    """Return the grouping key for mappings related to a primary source id."""
+    return mapping.mapping_type, mapping.source_system, source_id
+
+
+def _to_mapping_payload(mapping: FMUIdentifierMapping) -> dict[str, Any]:
+    """Return a payload compatible with fmu-datamodels mapping models."""
+    payload = mapping.model_dump()
+    payload["relation_type"] = RelationType(mapping.relation_type.value)
+    return payload

--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -68,7 +68,7 @@ class InternalIdentifierMapping(InternalBaseMapping):
 
     The internal storage schema allows same-system primaries and aliases, and it
     allows cross-system unmappable mappings without target identifiers.
-    fmu-datamodels identifier mappings only represent cross-system primary and
+    fmu-datamodels ``IdentifierMapping`` only represent cross-system primary and
     alias mappings with targets.
     """
 

--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -18,7 +18,7 @@ from fmu.datamodels.context.mappings import (
 )
 
 
-class FMURelationType(StrEnum):
+class InternalRelationType(StrEnum):
     """The kind of relation a .fmu mapping represents."""
 
     primary = "primary"
@@ -31,13 +31,13 @@ class FMURelationType(StrEnum):
     """A source identifier that has been reviewed and cannot be mapped."""
 
 
-class FMUBaseMapping(BaseModel):
+class InternalBaseMapping(BaseModel):
     """Base mapping fields stored in a .fmu mappings file."""
 
     source_system: DataSystem
     target_system: DataSystem
     mapping_type: MappingType
-    relation_type: FMURelationType
+    relation_type: InternalRelationType
 
     @model_validator(mode="after")
     def validate_relation_system_constraints(self: Self) -> Self:
@@ -47,19 +47,19 @@ class FMUBaseMapping(BaseModel):
         Cross-system mappings can only be ``primary`` or ``unmappable``.
         """
         if self.source_system == self.target_system:
-            if self.relation_type == FMURelationType.unmappable:
+            if self.relation_type == InternalRelationType.unmappable:
                 raise ValueError(
                     "Same-system mapping cannot use relation_type 'unmappable'"
                 )
             return self
 
-        if self.relation_type == FMURelationType.alias:
+        if self.relation_type == InternalRelationType.alias:
             raise ValueError("Cross-system mapping cannot use relation_type 'alias'")
 
         return self
 
 
-class FMUIdentifierMapping(FMUBaseMapping):
+class InternalIdentifierMapping(InternalBaseMapping):
     """Identifier mapping stored in a .fmu mappings file."""
 
     source_id: str
@@ -97,7 +97,7 @@ class FMUIdentifierMapping(FMUBaseMapping):
         - same-system ``alias`` mappings must point to a different same-system
           ``target_id``
         """
-        if self.relation_type == FMURelationType.unmappable:
+        if self.relation_type == InternalRelationType.unmappable:
             if self.target_id is not None or self.target_uuid is not None:
                 raise ValueError(
                     "Unmappable mapping cannot define target_id or target_uuid"
@@ -110,7 +110,7 @@ class FMUIdentifierMapping(FMUBaseMapping):
             )
 
         if self.source_system == self.target_system:
-            if self.relation_type == FMURelationType.primary:
+            if self.relation_type == InternalRelationType.primary:
                 if self.source_id != self.target_id:
                     raise ValueError(
                         "Same-system primary mapping must have matching source_id "
@@ -119,7 +119,7 @@ class FMUIdentifierMapping(FMUBaseMapping):
                     )
                 return self
 
-            if self.relation_type == FMURelationType.alias:
+            if self.relation_type == InternalRelationType.alias:
                 if self.source_id == self.target_id:
                     raise ValueError(
                         "Same-system alias mapping must have different source_id "
@@ -131,22 +131,24 @@ class FMUIdentifierMapping(FMUBaseMapping):
         return self
 
 
-class FMUStratigraphyIdentifierMapping(FMUIdentifierMapping):
+class InternalStratigraphyIdentifierMapping(InternalIdentifierMapping):
     """Stratigraphy identifier mapping stored in a .fmu mappings file."""
 
     mapping_type: Literal[MappingType.stratigraphy] = MappingType.stratigraphy
 
 
-class FMUWellboreIdentifierMapping(FMUIdentifierMapping):
+class InternalWellboreIdentifierMapping(InternalIdentifierMapping):
     """Wellbore identifier mapping stored in a .fmu mappings file."""
 
     mapping_type: Literal[MappingType.wellbore] = MappingType.wellbore
 
 
-class FMUStratigraphyMappings(RootModel[list[FMUStratigraphyIdentifierMapping]]):
+class InternalStratigraphyMappings(
+    RootModel[list[InternalStratigraphyIdentifierMapping]]
+):
     """Collection of stratigraphy mappings stored in a .fmu mappings file."""
 
-    root: list[FMUStratigraphyIdentifierMapping]
+    root: list[InternalStratigraphyIdentifierMapping]
 
     @model_validator(mode="after")
     def validate_collection(self: Self) -> Self:
@@ -163,11 +165,11 @@ class FMUStratigraphyMappings(RootModel[list[FMUStratigraphyIdentifierMapping]])
             ]
         )
 
-    def __getitem__(self: Self, index: int) -> FMUStratigraphyIdentifierMapping:
+    def __getitem__(self: Self, index: int) -> InternalStratigraphyIdentifierMapping:
         """Retrieve a stratigraphy mapping from the list by index."""
         return self.root[index]
 
-    def __iter__(self: Self) -> Iterator[FMUStratigraphyIdentifierMapping]:  # type: ignore[override]
+    def __iter__(self: Self) -> Iterator[InternalStratigraphyIdentifierMapping]:  # type: ignore[override]
         """Return an iterator for the stratigraphy mappings."""
         return iter(self.root)
 
@@ -176,10 +178,10 @@ class FMUStratigraphyMappings(RootModel[list[FMUStratigraphyIdentifierMapping]])
         return len(self.root)
 
 
-class FMUWellboreMappings(RootModel[list[FMUWellboreIdentifierMapping]]):
+class InternalWellboreMappings(RootModel[list[InternalWellboreIdentifierMapping]]):
     """Collection of wellbore mappings stored in a .fmu mappings file."""
 
-    root: list[FMUWellboreIdentifierMapping]
+    root: list[InternalWellboreIdentifierMapping]
 
     @model_validator(mode="after")
     def validate_collection(self: Self) -> Self:
@@ -196,11 +198,11 @@ class FMUWellboreMappings(RootModel[list[FMUWellboreIdentifierMapping]]):
             ]
         )
 
-    def __getitem__(self: Self, index: int) -> FMUWellboreIdentifierMapping:
+    def __getitem__(self: Self, index: int) -> InternalWellboreIdentifierMapping:
         """Retrieve a wellbore mapping from the list by index."""
         return self.root[index]
 
-    def __iter__(self: Self) -> Iterator[FMUWellboreIdentifierMapping]:  # type: ignore[override]
+    def __iter__(self: Self) -> Iterator[InternalWellboreIdentifierMapping]:  # type: ignore[override]
         """Return an iterator for the wellbore mappings."""
         return iter(self.root)
 
@@ -209,22 +211,22 @@ class FMUWellboreMappings(RootModel[list[FMUWellboreIdentifierMapping]]):
         return len(self.root)
 
 
-class FMUMappings(BaseModel):
+class InternalMappings(BaseModel):
     """Represents the mappings file in a .fmu directory."""
 
-    stratigraphy: FMUStratigraphyMappings = Field(
-        default_factory=lambda: FMUStratigraphyMappings(root=[])
+    stratigraphy: InternalStratigraphyMappings = Field(
+        default_factory=lambda: InternalStratigraphyMappings(root=[])
     )
     """Stratigraphy mappings in the mappings file."""
 
-    wellbore: FMUWellboreMappings = Field(
-        default_factory=lambda: FMUWellboreMappings(root=[])
+    wellbore: InternalWellboreMappings = Field(
+        default_factory=lambda: InternalWellboreMappings(root=[])
     )
     """Wellbore mappings in the mappings file."""
 
 
 def _validate_identifier_mappings_collection(
-    mappings: Sequence[FMUIdentifierMapping],
+    mappings: Sequence[InternalIdentifierMapping],
 ) -> None:
     """Validate how mappings are allowed to fit together.
 
@@ -276,11 +278,11 @@ def _validate_identifier_mappings_collection(
     """
     same_system_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
     same_system_primary_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
-    same_system_aliases: list[FMUIdentifierMapping] = []
+    same_system_aliases: list[InternalIdentifierMapping] = []
     cross_system_source_keys: set[tuple[MappingType, DataSystem, DataSystem, str]] = (
         set()
     )
-    cross_system_mappings: list[FMUIdentifierMapping] = []
+    cross_system_mappings: list[InternalIdentifierMapping] = []
 
     for mapping in mappings:
         source_key = (
@@ -296,7 +298,7 @@ def _validate_identifier_mappings_collection(
                 raise ValueError("Same-system mappings cannot reuse the same source_id")
             same_system_source_keys.add(source_key)
 
-            if mapping.relation_type == FMURelationType.primary:
+            if mapping.relation_type == InternalRelationType.primary:
                 same_system_primary_source_keys.add(source_key)
             else:
                 same_system_aliases.append(mapping)
@@ -348,7 +350,7 @@ def _validate_identifier_mappings_collection(
 
 
 def _get_identifier_mapping_payloads(
-    mappings: Sequence[FMUIdentifierMapping],
+    mappings: Sequence[InternalIdentifierMapping],
 ) -> list[dict[str, Any]]:
     """Return payloads for the identifier mapping models from fmu-datamodels.
 
@@ -380,7 +382,7 @@ def _get_identifier_mapping_payloads(
     fmu-datamodels mapping payloads.
     """
     aliases_by_primary: dict[
-        tuple[MappingType, DataSystem, str], list[FMUIdentifierMapping]
+        tuple[MappingType, DataSystem, str], list[InternalIdentifierMapping]
     ] = {}
 
     # Group same-system aliases by the same-system primary id they point to.
@@ -415,32 +417,32 @@ def _get_identifier_mapping_payloads(
     return mapping_payloads
 
 
-def _is_same_system_alias(mapping: FMUIdentifierMapping) -> bool:
+def _is_same_system_alias(mapping: InternalIdentifierMapping) -> bool:
     """Return whether a mapping is a same-system alias."""
     return (
         mapping.source_system == mapping.target_system
-        and mapping.relation_type == FMURelationType.alias
+        and mapping.relation_type == InternalRelationType.alias
         and mapping.target_id is not None
     )
 
 
-def _is_cross_system_primary(mapping: FMUIdentifierMapping) -> bool:
+def _is_cross_system_primary(mapping: InternalIdentifierMapping) -> bool:
     """Return whether a mapping is a cross-system primary with a target."""
     return (
         mapping.source_system != mapping.target_system
-        and mapping.relation_type == FMURelationType.primary
+        and mapping.relation_type == InternalRelationType.primary
         and mapping.target_id is not None
     )
 
 
 def _primary_key(
-    mapping: FMUIdentifierMapping, source_id: str
+    mapping: InternalIdentifierMapping, source_id: str
 ) -> tuple[MappingType, DataSystem, str]:
     """Return the grouping key for mappings related to a primary source id."""
     return mapping.mapping_type, mapping.source_system, source_id
 
 
-def _to_mapping_payload(mapping: FMUIdentifierMapping) -> dict[str, Any]:
+def _to_mapping_payload(mapping: InternalIdentifierMapping) -> dict[str, Any]:
     """Return a payload compatible with fmu-datamodels mapping models."""
     payload = mapping.model_dump()
     payload["relation_type"] = RelationType(mapping.relation_type.value)

--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -19,7 +19,7 @@ from fmu.datamodels.context.mappings import (
 
 
 class InternalRelationType(StrEnum):
-    """The kind of relation a .fmu mapping represents."""
+    """The kind of relation this internal .fmu mapping represents."""
 
     primary = "primary"
     """The main source identifier to use for this mapping."""
@@ -32,7 +32,11 @@ class InternalRelationType(StrEnum):
 
 
 class InternalBaseMapping(BaseModel):
-    """Base mapping fields stored in a .fmu mappings file."""
+    """Base fields for internal mappings stored in .fmu/mappings.json.
+
+    Unlike the fmu-datamodels mapping models, internal mappings may represent
+    same-system relationships and unmappable source identifiers.
+    """
 
     source_system: DataSystem
     target_system: DataSystem
@@ -60,7 +64,13 @@ class InternalBaseMapping(BaseModel):
 
 
 class InternalIdentifierMapping(InternalBaseMapping):
-    """Identifier mapping stored in a .fmu mappings file."""
+    """Identifier mapping stored in .fmu/mappings.json.
+
+    The internal storage schema allows same-system primaries and aliases, and it
+    allows cross-system unmappable mappings without target identifiers.
+    fmu-datamodels identifier mappings only represent cross-system primary and
+    alias mappings with targets.
+    """
 
     source_id: str
     source_uuid: UUID | None = None
@@ -132,13 +142,21 @@ class InternalIdentifierMapping(InternalBaseMapping):
 
 
 class InternalStratigraphyIdentifierMapping(InternalIdentifierMapping):
-    """Stratigraphy identifier mapping stored in a .fmu mappings file."""
+    """Stratigraphy identifier mapping stored in .fmu/mappings.json.
+
+    Use ``to_stratigraphy_mappings()`` on the collection model when consumers
+    need the fmu-datamodels mapping schema.
+    """
 
     mapping_type: Literal[MappingType.stratigraphy] = MappingType.stratigraphy
 
 
 class InternalWellboreIdentifierMapping(InternalIdentifierMapping):
-    """Wellbore identifier mapping stored in a .fmu mappings file."""
+    """Wellbore identifier mapping stored in .fmu/mappings.json.
+
+    Use ``to_wellbore_mappings()`` on the collection model when consumers need
+    the fmu-datamodels mapping schema.
+    """
 
     mapping_type: Literal[MappingType.wellbore] = MappingType.wellbore
 
@@ -146,7 +164,12 @@ class InternalWellboreIdentifierMapping(InternalIdentifierMapping):
 class InternalStratigraphyMappings(
     RootModel[list[InternalStratigraphyIdentifierMapping]]
 ):
-    """Collection of stratigraphy mappings stored in a .fmu mappings file."""
+    """Collection of stratigraphy mappings stored in .fmu/mappings.json.
+
+    This internal model can keep same-system alias information and unmappable
+    relation. Converting to fmu-datamodels drops unmappable entries and expands
+    same-system aliases onto matching cross-system primary mappings.
+    """
 
     root: list[InternalStratigraphyIdentifierMapping]
 
@@ -161,7 +184,7 @@ class InternalStratigraphyMappings(
         return StratigraphyMappings(
             root=[
                 StratigraphyIdentifierMapping(**mapping)
-                for mapping in _get_identifier_mapping_payloads(self.root)
+                for mapping in _to_datamodels_identifier_mapping_payloads(self.root)
             ]
         )
 
@@ -179,7 +202,12 @@ class InternalStratigraphyMappings(
 
 
 class InternalWellboreMappings(RootModel[list[InternalWellboreIdentifierMapping]]):
-    """Collection of wellbore mappings stored in a .fmu mappings file."""
+    """Collection of wellbore mappings stored in .fmu/mappings.json.
+
+    This internal model can keep same-system alias information and unmappable
+    relation. Converting to fmu-datamodels drops unmappable entries and expands
+    same-system aliases onto matching cross-system primary mappings.
+    """
 
     root: list[InternalWellboreIdentifierMapping]
 
@@ -194,7 +222,7 @@ class InternalWellboreMappings(RootModel[list[InternalWellboreIdentifierMapping]
         return WellboreMappings(
             root=[
                 WellboreIdentifierMapping(**mapping)
-                for mapping in _get_identifier_mapping_payloads(self.root)
+                for mapping in _to_datamodels_identifier_mapping_payloads(self.root)
             ]
         )
 
@@ -212,7 +240,7 @@ class InternalWellboreMappings(RootModel[list[InternalWellboreIdentifierMapping]
 
 
 class InternalMappings(BaseModel):
-    """Represents the mappings file in a .fmu directory."""
+    """Represents the .fmu/mappings.json storage schema."""
 
     stratigraphy: InternalStratigraphyMappings = Field(
         default_factory=lambda: InternalStratigraphyMappings(root=[])
@@ -228,7 +256,7 @@ class InternalMappings(BaseModel):
 def _validate_identifier_mappings_collection(
     mappings: Sequence[InternalIdentifierMapping],
 ) -> None:
-    """Validate how mappings are allowed to fit together.
+    """Validate how mappings are allowed to fit together when stored internally.
 
     The collection must satisfy three invariants:
 
@@ -349,10 +377,10 @@ def _validate_identifier_mappings_collection(
             )
 
 
-def _get_identifier_mapping_payloads(
+def _to_datamodels_identifier_mapping_payloads(
     mappings: Sequence[InternalIdentifierMapping],
 ) -> list[dict[str, Any]]:
-    """Return payloads for the identifier mapping models from fmu-datamodels.
+    """Convert internal mappings to fmu-datamodels identifier mapping payloads.
 
     Stored .fmu mappings can describe relationships inside the same system, for
     example ``rms -> rms`` primaries and aliases. Downstream consumers often need

--- a/tests/test_drogon/test_drogon_fmu_dir.py
+++ b/tests/test_drogon/test_drogon_fmu_dir.py
@@ -25,10 +25,12 @@ def test_create_drogon_fmu_roundtrip(tmp_path: Path) -> None:
     assert config_dict["model"] == MODEL
     assert config_dict["access"] == ACCESS
 
-    mappings_dict = fmu_dir.mappings.load().model_dump(mode="json")
+    stratigraphy_mappings = fmu_dir.mappings.stratigraphy_mappings.model_dump(
+        mode="json"
+    )
 
     strat_mappings = []
-    for strat_mapping in mappings_dict.get("stratigraphy", []):
+    for strat_mapping in stratigraphy_mappings:
         assert strat_mapping.get("mapping_type") == "stratigraphy"
         assert strat_mapping.get("source_uuid") is None
 

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -34,27 +34,29 @@ from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.change_info import ChangeInfo
 from fmu.settings.models.log import Log
 from fmu.settings.models.mappings import (
-    FMUMappings,
-    FMURelationType,
-    FMUStratigraphyIdentifierMapping,
-    FMUStratigraphyMappings,
+    InternalMappings,
+    InternalRelationType,
+    InternalStratigraphyIdentifierMapping,
+    InternalStratigraphyMappings,
 )
 
 
-def _stratigraphy_mappings(source_id: str, target_id: str) -> FMUStratigraphyMappings:
-    return FMUStratigraphyMappings(
+def _stratigraphy_mappings(
+    source_id: str, target_id: str
+) -> InternalStratigraphyMappings:
+    return InternalStratigraphyMappings(
         root=[
-            FMUStratigraphyIdentifierMapping(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.rms,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 target_id=source_id,
             ),
-            FMUStratigraphyIdentifierMapping(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.smda,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 target_id=target_id,
             ),
@@ -301,7 +303,7 @@ def test_restore_from_cache_restores_mappings(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Restoring mappings should refresh the resource cache."""
-    cached_mappings = FMUMappings(
+    cached_mappings = InternalMappings(
         stratigraphy=_stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
     )
     snapshot = fmu_dir.cache.store_revision(
@@ -310,7 +312,7 @@ def test_restore_from_cache_restores_mappings(
     )
     assert snapshot is not None
 
-    current_mappings = FMUMappings(
+    current_mappings = InternalMappings(
         stratigraphy=_stratigraphy_mappings("TopTherys", "THERYS GP. Top")
     )
     fmu_dir.mappings.save(current_mappings)
@@ -623,7 +625,7 @@ def test_restore_rebuilds_project_fmu_from_cache(
     """Tests that restore should recreate missing files using cached config data."""
     fmu_dir.update_config({"version": "123.4.5"})
     cached_dump = json.loads((fmu_dir.path / "config.json").read_text())
-    fmu_dir.mappings.update_fmu_stratigraphy_mappings(
+    fmu_dir.mappings.update_internal_stratigraphy_mappings(
         _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
     )
     cached_mappings_dump = json.loads((fmu_dir.path / "mappings.json").read_text())
@@ -708,7 +710,7 @@ def test_list_restorable_files_reports_missing_project_files(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests list_restorable_files reports only files restore would recreate."""
-    fmu_dir.mappings.update_fmu_stratigraphy_mappings(
+    fmu_dir.mappings.update_internal_stratigraphy_mappings(
         _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
     )
 
@@ -734,7 +736,7 @@ def test_list_restorable_files_skips_project_mappings_without_cache(
     assert fmu_dir.list_restorable_files() == []
 
 
-def test_fmu_directory_base_exposes_lock_timeout_kwarg() -> None:
+def test_internal_directory_base_exposes_lock_timeout_kwarg() -> None:
     """Tests that the kw-only lock timeout argument remains available."""
     signature = inspect.signature(FMUDirectoryBase.__init__)
     lock_timeout = signature.parameters.get("lock_timeout_seconds")
@@ -868,7 +870,7 @@ def test_find_rms_projects_with_config_path(
     assert fmu_dir2.get_config_value("rms").path == rms_project
 
 
-def test_fmu_directory_base_get_dir_diff_with_other_fmu_dir(
+def test_internal_directory_base_get_dir_diff_with_other_fmu_dir(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -886,7 +888,7 @@ def test_fmu_directory_base_get_dir_diff_with_other_fmu_dir(
     assert diff_fmu_dir["config"][0][2] == Masterdata.model_validate(masterdata_dict)
 
 
-def test_fmu_directory_base_get_dir_diff_only_diff_whitelisted_resources(
+def test_internal_directory_base_get_dir_diff_only_diff_whitelisted_resources(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -908,7 +910,7 @@ def test_fmu_directory_base_get_dir_diff_only_diff_whitelisted_resources(
     assert "_lock" not in diff_fmu_dir
 
 
-def test_fmu_directory_base_get_dir_diff_skip_when_resource_not_exist(
+def test_internal_directory_base_get_dir_diff_skip_when_resource_not_exist(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -924,7 +926,7 @@ def test_fmu_directory_base_get_dir_diff_skip_when_resource_not_exist(
     assert len(diff_fmu_dir) == 0
 
 
-def test_fmu_directory_base_sync_dir_with_other_fmu_dir(
+def test_internal_directory_base_sync_dir_with_other_fmu_dir(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -946,7 +948,7 @@ def test_fmu_directory_base_sync_dir_with_other_fmu_dir(
     assert new_fmu_dir.config.load().masterdata == fmu_dir.config.load().masterdata
 
 
-def test_fmu_directory_base_sync_dir_only_whitelisted_resources(
+def test_internal_directory_base_sync_dir_only_whitelisted_resources(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -969,7 +971,7 @@ def test_fmu_directory_base_sync_dir_only_whitelisted_resources(
     assert not fmu_dir._lock.exists
 
 
-def test_fmu_directory_base_sync_dir_skip_when_resource_not_exist(
+def test_internal_directory_base_sync_dir_skip_when_resource_not_exist(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -984,7 +986,7 @@ def test_fmu_directory_base_sync_dir_skip_when_resource_not_exist(
     assert len(updates) == 0
 
 
-def test_fmu_directory_base_sync_dir_skip_when_no_diff(
+def test_internal_directory_base_sync_dir_skip_when_no_diff(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1001,7 +1003,7 @@ def test_fmu_directory_base_sync_dir_skip_when_no_diff(
     assert len(updates) == 0
 
 
-def test_fmu_directory_base_sync_runtime_variables(
+def test_internal_directory_base_sync_runtime_variables(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1169,7 +1171,7 @@ def test_restore_from_cache_higher_cache_max_revisions_does_not_trim_to_old_limi
     assert len(fmu_dir.cache.list_revisions("config.json")) == expected_revision_count
 
 
-def test_fmu_directory_base_get_dir_diff_with_same_changelog(
+def test_internal_directory_base_get_dir_diff_with_same_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1191,7 +1193,7 @@ def test_fmu_directory_base_get_dir_diff_with_same_changelog(
         assert len(change_list) == 0, f"Resource {resource} has changes"
 
 
-def test_fmu_directory_base_get_dir_diff_with_changelog(
+def test_internal_directory_base_get_dir_diff_with_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1239,7 +1241,7 @@ def test_fmu_directory_base_get_dir_diff_with_changelog(
     assert changelog_diff[0][2].root[0] == new_log_entry
 
 
-def test_fmu_directory_base_sync_dir_with_changelog(
+def test_internal_directory_base_sync_dir_with_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1285,7 +1287,7 @@ def test_fmu_directory_base_sync_dir_with_changelog(
     assert updated_changelog[2].path == fmu_dir.path
 
 
-def test_fmu_directory_base_sync_dir_with_all_resources(
+def test_internal_directory_base_sync_dir_with_all_resources(
     fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
     extra_fmu_dir: ProjectFMUDirectory,
@@ -1297,10 +1299,12 @@ def test_fmu_directory_base_sync_dir_with_all_resources(
     assert len(fmu_dir._changelog.load()) == 1
     assert fmu_dir._changelog.load()[0].change_type == ChangeType.update
 
-    fmu_dir._mappings.update_fmu_stratigraphy_mappings(FMUStratigraphyMappings(root=[]))
+    fmu_dir._mappings.update_internal_stratigraphy_mappings(
+        InternalStratigraphyMappings(root=[])
+    )
     new_fmu_dir = extra_fmu_dir
     new_strat_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
-    new_fmu_dir._mappings.update_fmu_stratigraphy_mappings(new_strat_mappings)
+    new_fmu_dir._mappings.update_internal_stratigraphy_mappings(new_strat_mappings)
 
     assert len(new_fmu_dir._changelog.load()) == 1
     assert new_fmu_dir._changelog.load()[0].key == "stratigraphy"
@@ -1314,9 +1318,9 @@ def test_fmu_directory_base_sync_dir_with_all_resources(
     assert fmu_dir.config.load().masterdata is None
 
     assert "_mappings" in updated_resources
-    assert len(fmu_dir._mappings.fmu_wellbore_mappings) == 0
-    assert len(fmu_dir._mappings.fmu_stratigraphy_mappings) == 2
-    assert fmu_dir._mappings.fmu_stratigraphy_mappings == new_strat_mappings
+    assert len(fmu_dir._mappings.internal_wellbore_mappings) == 0
+    assert len(fmu_dir._mappings.internal_stratigraphy_mappings) == 2
+    assert fmu_dir._mappings.internal_stratigraphy_mappings == new_strat_mappings
 
     assert "_changelog" in updated_resources
     updated_changelog: Log[ChangeInfo] = updated_resources["_changelog"]
@@ -1347,7 +1351,7 @@ def test_fmu_directory_base_sync_dir_with_all_resources(
     assert "_mappings" in updated_changelog[5].file
 
 
-def test_fmu_directory_base_sync_dir_dont_sync_ignored_fields(
+def test_internal_directory_base_sync_dir_dont_sync_ignored_fields(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1414,17 +1418,17 @@ def test_fmu_directory_base_sync_dir_dont_sync_ignored_fields(
     assert "Old value: user -> New value: johndoe" in updates["_changelog"][4].change
 
 
-def test_fmu_directory_base_get_dir_diff_with_mappings(
+def test_internal_directory_base_get_dir_diff_with_mappings(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests getting the diff with another .fmu directory with mappings."""
     strat_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
-    fmu_dir._mappings.update_fmu_stratigraphy_mappings(strat_mappings)
+    fmu_dir._mappings.update_internal_stratigraphy_mappings(strat_mappings)
 
     new_fmu_dir = extra_fmu_dir
     new_strat_mappings = _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
-    new_fmu_dir._mappings.update_fmu_stratigraphy_mappings(new_strat_mappings)
+    new_fmu_dir._mappings.update_internal_stratigraphy_mappings(new_strat_mappings)
 
     old_fmu_dir = copy.deepcopy(fmu_dir)
     dir_diff = fmu_dir.get_dir_diff(new_fmu_dir)
@@ -1440,7 +1444,7 @@ def test_fmu_directory_base_get_dir_diff_with_mappings(
     mappings_diff = dir_diff["_mappings"][0]
     assert mappings_diff[0] == "mappings"
     assert mappings_diff[1] is None
-    assert isinstance(mappings_diff[2], FMUMappings)
+    assert isinstance(mappings_diff[2], InternalMappings)
     assert len(mappings_diff[2].wellbore) == 0
     assert len(mappings_diff[2].stratigraphy) == 2
     assert mappings_diff[2].stratigraphy == new_strat_mappings
@@ -1459,26 +1463,26 @@ def test_fmu_directory_base_get_dir_diff_with_mappings(
     assert changelog_diff[2][0].file == "mappings.json"
 
 
-def test_fmu_directory_base_sync_dir_with_mappings(
+def test_internal_directory_base_sync_dir_with_mappings(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests syncing mappings resource with another .fmu directory."""
     strat_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
-    fmu_dir._mappings.update_fmu_stratigraphy_mappings(strat_mappings)
+    fmu_dir._mappings.update_internal_stratigraphy_mappings(strat_mappings)
 
     new_fmu_dir = extra_fmu_dir
     new_strat_mappings = _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
-    new_fmu_dir._mappings.update_fmu_stratigraphy_mappings(new_strat_mappings)
+    new_fmu_dir._mappings.update_internal_stratigraphy_mappings(new_strat_mappings)
 
     updates = fmu_dir.sync_dir(new_fmu_dir)
 
     # Assert mappings are updated as expected
     assert "_mappings" in updates
     assert updates["_mappings"] == fmu_dir._mappings.load()
-    assert len(fmu_dir._mappings.fmu_wellbore_mappings) == 0
-    assert len(fmu_dir._mappings.fmu_stratigraphy_mappings) == 2
-    assert fmu_dir._mappings.fmu_stratigraphy_mappings == new_strat_mappings
+    assert len(fmu_dir._mappings.internal_wellbore_mappings) == 0
+    assert len(fmu_dir._mappings.internal_stratigraphy_mappings) == 2
+    assert fmu_dir._mappings.internal_stratigraphy_mappings == new_strat_mappings
 
     # Assert no config changes
     assert "config" not in updates

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -12,9 +12,6 @@ import pytest
 from fmu.datamodels.common.masterdata import Masterdata
 from fmu.datamodels.context.mappings import (
     DataSystem,
-    RelationType,
-    StratigraphyIdentifierMapping,
-    StratigraphyMappings,
 )
 from pytest import MonkeyPatch
 
@@ -36,7 +33,33 @@ from fmu.settings._resources.mappings_manager import MappingsManager
 from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.change_info import ChangeInfo
 from fmu.settings.models.log import Log
-from fmu.settings.models.mappings import Mappings
+from fmu.settings.models.mappings import (
+    FMUMappings,
+    FMURelationType,
+    FMUStratigraphyIdentifierMapping,
+    FMUStratigraphyMappings,
+)
+
+
+def _stratigraphy_mappings(source_id: str, target_id: str) -> FMUStratigraphyMappings:
+    return FMUStratigraphyMappings(
+        root=[
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.rms,
+                relation_type=FMURelationType.primary,
+                source_id=source_id,
+                target_id=source_id,
+            ),
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.smda,
+                relation_type=FMURelationType.primary,
+                source_id=source_id,
+                target_id=target_id,
+            ),
+        ]
+    )
 
 
 def test_init_existing_directory(fmu_dir: ProjectFMUDirectory) -> None:
@@ -278,29 +301,17 @@ def test_restore_from_cache_restores_mappings(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Restoring mappings should refresh the resource cache."""
-    cached_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="VOLANTIS GP. Top",
+    cached_mappings = FMUMappings(
+        stratigraphy=_stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
     )
-    cached_mappings = Mappings(stratigraphy=StratigraphyMappings(root=[cached_mapping]))
     snapshot = fmu_dir.cache.store_revision(
         CacheResource.mappings.value,
         cached_mappings.model_dump_json(by_alias=True, indent=2),
     )
     assert snapshot is not None
 
-    current_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopTherys",
-        target_id="THERYS GP. Top",
-    )
-    current_mappings = Mappings(
-        stratigraphy=StratigraphyMappings(root=[current_mapping])
+    current_mappings = FMUMappings(
+        stratigraphy=_stratigraphy_mappings("TopTherys", "THERYS GP. Top")
     )
     fmu_dir.mappings.save(current_mappings)
 
@@ -612,15 +623,8 @@ def test_restore_rebuilds_project_fmu_from_cache(
     """Tests that restore should recreate missing files using cached config data."""
     fmu_dir.update_config({"version": "123.4.5"})
     cached_dump = json.loads((fmu_dir.path / "config.json").read_text())
-    cached_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="VOLANTIS GP. Top",
-    )
-    fmu_dir.mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[cached_mapping])
+    fmu_dir.mappings.update_fmu_stratigraphy_mappings(
+        _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
     )
     cached_mappings_dump = json.loads((fmu_dir.path / "mappings.json").read_text())
 
@@ -704,15 +708,8 @@ def test_list_restorable_files_reports_missing_project_files(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests list_restorable_files reports only files restore would recreate."""
-    cached_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="VOLANTIS GP. Top",
-    )
-    fmu_dir.mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[cached_mapping])
+    fmu_dir.mappings.update_fmu_stratigraphy_mappings(
+        _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
     )
 
     (fmu_dir.path / "README").unlink()
@@ -1300,18 +1297,10 @@ def test_fmu_directory_base_sync_dir_with_all_resources(
     assert len(fmu_dir._changelog.load()) == 1
     assert fmu_dir._changelog.load()[0].change_type == ChangeType.update
 
-    fmu_dir._mappings.update_stratigraphy_mappings(StratigraphyMappings(root=[]))
+    fmu_dir._mappings.update_fmu_stratigraphy_mappings(FMUStratigraphyMappings(root=[]))
     new_fmu_dir = extra_fmu_dir
-    new_strat_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
-    )
-    new_fmu_dir._mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[new_strat_mapping])
-    )
+    new_strat_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
+    new_fmu_dir._mappings.update_fmu_stratigraphy_mappings(new_strat_mappings)
 
     assert len(new_fmu_dir._changelog.load()) == 1
     assert new_fmu_dir._changelog.load()[0].key == "stratigraphy"
@@ -1325,9 +1314,9 @@ def test_fmu_directory_base_sync_dir_with_all_resources(
     assert fmu_dir.config.load().masterdata is None
 
     assert "_mappings" in updated_resources
-    assert len(fmu_dir._mappings.wellbore_mappings) == 0
-    assert len(fmu_dir._mappings.stratigraphy_mappings) == 1
-    assert fmu_dir._mappings.stratigraphy_mappings[0] == new_strat_mapping
+    assert len(fmu_dir._mappings.fmu_wellbore_mappings) == 0
+    assert len(fmu_dir._mappings.fmu_stratigraphy_mappings) == 2
+    assert fmu_dir._mappings.fmu_stratigraphy_mappings == new_strat_mappings
 
     assert "_changelog" in updated_resources
     updated_changelog: Log[ChangeInfo] = updated_resources["_changelog"]
@@ -1430,24 +1419,12 @@ def test_fmu_directory_base_get_dir_diff_with_mappings(
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests getting the diff with another .fmu directory with mappings."""
-    strat_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
-    )
-    fmu_dir._mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[strat_mapping])
-    )
+    strat_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
+    fmu_dir._mappings.update_fmu_stratigraphy_mappings(strat_mappings)
 
     new_fmu_dir = extra_fmu_dir
-    new_strat_mapping = copy.deepcopy(strat_mapping)
-    new_strat_mapping.source_id = "TopVolantis"
-    new_strat_mapping.target_id = "VOLANTIS GP. Top"
-    new_fmu_dir._mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[new_strat_mapping])
-    )
+    new_strat_mappings = _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
+    new_fmu_dir._mappings.update_fmu_stratigraphy_mappings(new_strat_mappings)
 
     old_fmu_dir = copy.deepcopy(fmu_dir)
     dir_diff = fmu_dir.get_dir_diff(new_fmu_dir)
@@ -1463,10 +1440,10 @@ def test_fmu_directory_base_get_dir_diff_with_mappings(
     mappings_diff = dir_diff["_mappings"][0]
     assert mappings_diff[0] == "mappings"
     assert mappings_diff[1] is None
-    assert isinstance(mappings_diff[2], Mappings)
+    assert isinstance(mappings_diff[2], FMUMappings)
     assert len(mappings_diff[2].wellbore) == 0
-    assert len(mappings_diff[2].stratigraphy) == 1
-    assert mappings_diff[2].stratigraphy[0] == new_strat_mapping
+    assert len(mappings_diff[2].stratigraphy) == 2
+    assert mappings_diff[2].stratigraphy == new_strat_mappings
 
     # Assert no config changes
     assert "config" in dir_diff
@@ -1487,33 +1464,21 @@ def test_fmu_directory_base_sync_dir_with_mappings(
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests syncing mappings resource with another .fmu directory."""
-    strat_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
-    )
-    fmu_dir._mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[strat_mapping])
-    )
+    strat_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
+    fmu_dir._mappings.update_fmu_stratigraphy_mappings(strat_mappings)
 
     new_fmu_dir = extra_fmu_dir
-    new_strat_mapping = copy.deepcopy(strat_mapping)
-    new_strat_mapping.source_id = "TopVolantis"
-    new_strat_mapping.target_id = "VOLANTIS GP. Top"
-    new_fmu_dir._mappings.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[new_strat_mapping])
-    )
+    new_strat_mappings = _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
+    new_fmu_dir._mappings.update_fmu_stratigraphy_mappings(new_strat_mappings)
 
     updates = fmu_dir.sync_dir(new_fmu_dir)
 
     # Assert mappings are updated as expected
     assert "_mappings" in updates
     assert updates["_mappings"] == fmu_dir._mappings.load()
-    assert len(fmu_dir._mappings.wellbore_mappings) == 0
-    assert len(fmu_dir._mappings.stratigraphy_mappings) == 1
-    assert fmu_dir._mappings.stratigraphy_mappings[0] == new_strat_mapping
+    assert len(fmu_dir._mappings.fmu_wellbore_mappings) == 0
+    assert len(fmu_dir._mappings.fmu_stratigraphy_mappings) == 2
+    assert fmu_dir._mappings.fmu_stratigraphy_mappings == new_strat_mappings
 
     # Assert no config changes
     assert "config" not in updates

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -736,7 +736,7 @@ def test_list_restorable_files_skips_project_mappings_without_cache(
     assert fmu_dir.list_restorable_files() == []
 
 
-def test_internal_directory_base_exposes_lock_timeout_kwarg() -> None:
+def test_fmu_directory_base_exposes_lock_timeout_kwarg() -> None:
     """Tests that the kw-only lock timeout argument remains available."""
     signature = inspect.signature(FMUDirectoryBase.__init__)
     lock_timeout = signature.parameters.get("lock_timeout_seconds")
@@ -870,7 +870,7 @@ def test_find_rms_projects_with_config_path(
     assert fmu_dir2.get_config_value("rms").path == rms_project
 
 
-def test_internal_directory_base_get_dir_diff_with_other_fmu_dir(
+def test_fmu_directory_base_get_dir_diff_with_other_fmu_dir(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -888,7 +888,7 @@ def test_internal_directory_base_get_dir_diff_with_other_fmu_dir(
     assert diff_fmu_dir["config"][0][2] == Masterdata.model_validate(masterdata_dict)
 
 
-def test_internal_directory_base_get_dir_diff_only_diff_whitelisted_resources(
+def test_fmu_directory_base_get_dir_diff_only_diff_whitelisted_resources(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -910,7 +910,7 @@ def test_internal_directory_base_get_dir_diff_only_diff_whitelisted_resources(
     assert "_lock" not in diff_fmu_dir
 
 
-def test_internal_directory_base_get_dir_diff_skip_when_resource_not_exist(
+def test_fmu_directory_base_get_dir_diff_skip_when_resource_not_exist(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -926,7 +926,7 @@ def test_internal_directory_base_get_dir_diff_skip_when_resource_not_exist(
     assert len(diff_fmu_dir) == 0
 
 
-def test_internal_directory_base_sync_dir_with_other_fmu_dir(
+def test_fmu_directory_base_sync_dir_with_other_fmu_dir(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -948,7 +948,7 @@ def test_internal_directory_base_sync_dir_with_other_fmu_dir(
     assert new_fmu_dir.config.load().masterdata == fmu_dir.config.load().masterdata
 
 
-def test_internal_directory_base_sync_dir_only_whitelisted_resources(
+def test_fmu_directory_base_sync_dir_only_whitelisted_resources(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
@@ -971,7 +971,7 @@ def test_internal_directory_base_sync_dir_only_whitelisted_resources(
     assert not fmu_dir._lock.exists
 
 
-def test_internal_directory_base_sync_dir_skip_when_resource_not_exist(
+def test_fmu_directory_base_sync_dir_skip_when_resource_not_exist(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -986,7 +986,7 @@ def test_internal_directory_base_sync_dir_skip_when_resource_not_exist(
     assert len(updates) == 0
 
 
-def test_internal_directory_base_sync_dir_skip_when_no_diff(
+def test_fmu_directory_base_sync_dir_skip_when_no_diff(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1003,7 +1003,7 @@ def test_internal_directory_base_sync_dir_skip_when_no_diff(
     assert len(updates) == 0
 
 
-def test_internal_directory_base_sync_runtime_variables(
+def test_fmu_directory_base_sync_runtime_variables(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1171,7 +1171,7 @@ def test_restore_from_cache_higher_cache_max_revisions_does_not_trim_to_old_limi
     assert len(fmu_dir.cache.list_revisions("config.json")) == expected_revision_count
 
 
-def test_internal_directory_base_get_dir_diff_with_same_changelog(
+def test_fmu_directory_base_get_dir_diff_with_same_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1193,7 +1193,7 @@ def test_internal_directory_base_get_dir_diff_with_same_changelog(
         assert len(change_list) == 0, f"Resource {resource} has changes"
 
 
-def test_internal_directory_base_get_dir_diff_with_changelog(
+def test_fmu_directory_base_get_dir_diff_with_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1241,7 +1241,7 @@ def test_internal_directory_base_get_dir_diff_with_changelog(
     assert changelog_diff[0][2].root[0] == new_log_entry
 
 
-def test_internal_directory_base_sync_dir_with_changelog(
+def test_fmu_directory_base_sync_dir_with_changelog(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1287,7 +1287,7 @@ def test_internal_directory_base_sync_dir_with_changelog(
     assert updated_changelog[2].path == fmu_dir.path
 
 
-def test_internal_directory_base_sync_dir_with_all_resources(
+def test_fmu_directory_base_sync_dir_with_all_resources(
     fmu_dir: ProjectFMUDirectory,
     masterdata_dict: dict[str, Any],
     extra_fmu_dir: ProjectFMUDirectory,
@@ -1351,7 +1351,7 @@ def test_internal_directory_base_sync_dir_with_all_resources(
     assert "_mappings" in updated_changelog[5].file
 
 
-def test_internal_directory_base_sync_dir_dont_sync_ignored_fields(
+def test_fmu_directory_base_sync_dir_dont_sync_ignored_fields(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1418,7 +1418,7 @@ def test_internal_directory_base_sync_dir_dont_sync_ignored_fields(
     assert "Old value: user -> New value: johndoe" in updates["_changelog"][4].change
 
 
-def test_internal_directory_base_get_dir_diff_with_mappings(
+def test_fmu_directory_base_get_dir_diff_with_mappings(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:
@@ -1463,7 +1463,7 @@ def test_internal_directory_base_get_dir_diff_with_mappings(
     assert changelog_diff[2][0].file == "mappings.json"
 
 
-def test_internal_directory_base_sync_dir_with_mappings(
+def test_fmu_directory_base_sync_dir_with_mappings(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
 ) -> None:

--- a/tests/test_mappings_model.py
+++ b/tests/test_mappings_model.py
@@ -1,199 +1,642 @@
-"""Tests for mapping models."""
+"""Tests for validators in the .fmu mapping models."""
 
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from fmu.datamodels.context.mappings import (
     DataSystem,
     MappingType,
-    RelationType,
-    StratigraphyIdentifierMapping,
+    StratigraphyMappings,
+    WellboreMappings,
 )
-from pydantic import ValidationError
 
-from fmu.settings.models.mappings import MappingGroup
+from fmu.settings.models.mappings import (
+    FMUBaseMapping,
+    FMUIdentifierMapping,
+    FMUMappings,
+    FMURelationType,
+    FMUStratigraphyIdentifierMapping,
+    FMUStratigraphyMappings,
+    FMUWellboreIdentifierMapping,
+    FMUWellboreMappings,
+)
 
 
-def _make_mapping(  # noqa: PLR0913
-    source_id: str,
-    target_id: str,
-    relation_type: RelationType,
+def create_stratigraphy_mapping(
+    *,
     source_system: DataSystem = DataSystem.rms,
-    target_system: DataSystem = DataSystem.smda,
-    target_uuid: UUID | None = None,
-) -> StratigraphyIdentifierMapping:
-    return StratigraphyIdentifierMapping(
+    target_system: DataSystem = DataSystem.rms,
+    relation_type: FMURelationType = FMURelationType.primary,
+    source_id: str = "TopVolantis",
+    target_id: str | None = "TopVolantis",
+) -> FMUStratigraphyIdentifierMapping:
+    """Build an internal .fmu stratigraphy mapping with sensible defaults."""
+    return FMUStratigraphyIdentifierMapping(
         source_system=source_system,
         target_system=target_system,
         relation_type=relation_type,
         source_id=source_id,
         target_id=target_id,
-        target_uuid=target_uuid,
     )
 
 
-def test_mapping_group_count_mappings_by_relation_type() -> None:
-    """Tests that the count of mappings with the given relation_type is returned."""
-    target_id = "Viking GP."
-    primary = _make_mapping("Viking Gp", target_id, RelationType.primary)
-    alias = _make_mapping("Viking gp", target_id, RelationType.alias)
-    alias_two = _make_mapping("VIKING GP", target_id, RelationType.alias)
-    alias_three = _make_mapping("viking.gp", target_id, RelationType.alias)
-
-    mapping_group = MappingGroup(
+def create_wellbore_mapping(
+    *,
+    source_system: DataSystem = DataSystem.rms,
+    target_system: DataSystem = DataSystem.rms,
+    relation_type: FMURelationType = FMURelationType.primary,
+    source_id: str = "30_9-B-21_C",
+    target_id: str | None = "30_9-B-21_C",
+) -> FMUWellboreIdentifierMapping:
+    """Build an internal .fmu wellbore mapping with sensible defaults."""
+    return FMUWellboreIdentifierMapping(
+        source_system=source_system,
+        target_system=target_system,
+        relation_type=relation_type,
+        source_id=source_id,
         target_id=target_id,
-        mapping_type=MappingType.stratigraphy,
-        target_system=DataSystem.smda,
+    )
+
+
+@pytest.mark.parametrize(
+    "relation_type", [FMURelationType.primary, FMURelationType.alias]
+)
+def test_fmu_base_mapping_allows_same_system_primary_and_alias(
+    relation_type: FMURelationType,
+) -> None:
+    """Same-system primary and alias relations are allowed."""
+    FMUBaseMapping(
         source_system=DataSystem.rms,
-        mappings=[primary, alias, alias_two, alias_three],
-    )
-
-    assert mapping_group._count_mappings_by_relation_type(RelationType.primary) == 1
-    expected_alias_mappings = 3
-    assert (
-        mapping_group._count_mappings_by_relation_type(RelationType.alias)
-        == expected_alias_mappings
-    )
-
-
-def test_mapping_group_serializes_without_system_and_target_fields() -> None:
-    """MappingGroup serializes mappings without redundant fields."""
-    target_id = "Viking GP."
-    target_uuid = uuid4()
-    primary = _make_mapping(
-        "Viking Gp", target_id, RelationType.primary, target_uuid=target_uuid
-    )
-    alias = _make_mapping(
-        "Viking Group", target_id, RelationType.alias, target_uuid=target_uuid
-    )
-
-    group = MappingGroup(
-        target_id=target_id,
-        target_uuid=target_uuid,
+        target_system=DataSystem.rms,
         mapping_type=MappingType.stratigraphy,
-        target_system=DataSystem.smda,
-        source_system=DataSystem.rms,
-        mappings=[primary, alias],
+        relation_type=relation_type,
     )
 
-    display_dict = group.model_dump()
-    assert display_dict["official_name"] == target_id
-    assert display_dict["target_uuid"] == target_uuid
-    assert display_dict["mapping_type"] == "stratigraphy"
-    assert display_dict["target_system"] == "smda"
-    assert display_dict["source_system"] == "rms"
-    for mapping in display_dict["mappings"]:
-        assert "source_system" not in mapping
-        assert "target_system" not in mapping
-        assert "mapping_type" not in mapping
-        assert "target_id" not in mapping
-        assert "target_uuid" not in mapping
-        assert "relation_type" in mapping
-        assert "source_id" in mapping
+
+@pytest.mark.parametrize(
+    "relation_type", [FMURelationType.primary, FMURelationType.unmappable]
+)
+def test_fmu_base_mapping_allows_cross_system_primary_and_unmappable(
+    relation_type: FMURelationType,
+) -> None:
+    """Cross-system primary and unmappable relations are allowed."""
+    FMUBaseMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        mapping_type=MappingType.stratigraphy,
+        relation_type=relation_type,
+    )
 
 
-def test_mapping_group_rejects_multiple_primary_mappings() -> None:
-    """MappingGroup with more than one primary mapping raises ValidationError."""
-    target_id = "Viking GP."
-    primary = _make_mapping("Viking Gp", target_id, RelationType.primary)
-    primary_two = _make_mapping("Viking Gp 2", target_id, RelationType.primary)
-    with pytest.raises(ValidationError, match="at most one primary mapping."):
-        MappingGroup(
-            target_id=target_id,
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
-            source_system=DataSystem.rms,
-            mappings=[primary, primary_two],
-        )
-
-
-def test_mapping_group_with_alias_requires_primary_relation() -> None:
-    """MappingsGroup with alias mappings and no primary mapping raises ValidationError.
-
-    A MappingGroup containing alias mappings will raise a ValidationError
-    Error if no primary mapping exists.
-    """
-    target_id = "Viking GP."
-    alias = _make_mapping("Viking gp", target_id, RelationType.alias)
-    alias_two = _make_mapping("VIKING GP", target_id, RelationType.alias)
+def test_fmu_base_mapping_rejects_same_system_unmappable() -> None:
+    """Unmappable is only valid for cross-system mappings."""
     with pytest.raises(
-        ValidationError, match="contains alias relations but no primary relation."
+        ValueError,
+        match="Same-system mapping cannot use relation_type 'unmappable'",
     ):
-        MappingGroup(
-            target_id=target_id,
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
+        FMUBaseMapping(
             source_system=DataSystem.rms,
-            mappings=[alias, alias_two],
+            target_system=DataSystem.rms,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=FMURelationType.unmappable,
         )
 
 
-def test_mapping_group_requires_no_duplicate_mappings() -> None:
-    """MappingGroup with duplicate mappings raises ValidationError."""
-    target_id = "Viking GP."
-    primary = _make_mapping("VIKING GP", target_id, RelationType.primary)
-    alias = _make_mapping("Viking gp", target_id, RelationType.alias)
-    alias_two = _make_mapping("Viking gp", target_id, RelationType.alias)
-    with pytest.raises(ValidationError, match="Duplicate mapping in group:"):
-        MappingGroup(
-            target_id=target_id,
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
+def test_fmu_base_mapping_rejects_cross_system_alias() -> None:
+    """Alias is only valid for same-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Cross-system mapping cannot use relation_type 'alias'",
+    ):
+        FMUBaseMapping(
             source_system=DataSystem.rms,
-            mappings=[primary, alias, alias_two],
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=FMURelationType.alias,
         )
 
 
-def test_mapping_group_requires_shared_target_id() -> None:
-    """All mappings must share the group target_id."""
-    primary = _make_mapping("Viking Gp", "Viking GP.", RelationType.primary)
-    different_target = _make_mapping("westeros", "Westeros", RelationType.alias)
-
-    with pytest.raises(ValidationError, match="target_id"):
-        MappingGroup(
-            target_id="Viking GP.",
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
+def test_fmu_identifier_mapping_ids_not_empty_strings() -> None:
+    """Ensure that validation fails if a mapping identifier is an empty string."""
+    with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
+        FMUIdentifierMapping(
             source_system=DataSystem.rms,
-            mappings=[primary, different_target],
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=FMURelationType.primary,
+            source_id="",
+            target_id="foo",
         )
 
 
-def test_mapping_group_requires_shared_target_system() -> None:
-    """All mappings must share the group target_system."""
-    primary = _make_mapping("Viking Gp", "Viking GP.", RelationType.primary)
-    different_target_system = _make_mapping(
-        "Viking Gp 2",
-        "Viking GP.",
-        RelationType.alias,
+def test_fmu_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
+    """Source and target identifiers are stripped when they contain padding."""
+    mapping = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=FMURelationType.primary,
+        source_id="  TopVolantis  ",
+        target_id="  VOLANTIS GP. Top  ",
+    )
+
+    assert mapping.source_id == "TopVolantis"
+    assert mapping.target_id == "VOLANTIS GP. Top"
+
+
+def test_fmu_identifier_mapping_allows_same_system_primary_mapping_to_itself() -> None:
+    """Same-system primary mappings must map an identifier to itself."""
+    mapping = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        relation_type=FMURelationType.primary,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+
+    assert mapping.source_id == mapping.target_id
+
+
+def test_fmu_identifier_mapping_rejects_same_system_primary_to_other_id() -> None:
+    """Same-system primary mappings cannot map an identifier to another one."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Same-system primary mapping must have matching source_id and "
+            "target_id; use relation_type='alias' if they should differ"
+        ),
+    ):
+        create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.rms,
+            relation_type=FMURelationType.primary,
+            source_id="TopVolantis",
+            target_id="TopVolon",
+        )
+
+
+def test_fmu_identifier_mapping_allows_same_system_alias() -> None:
+    """Same-system aliases can point to a primary identifier."""
+    mapping = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        relation_type=FMURelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+
+    assert mapping.source_id == "TOP_VOLANTIS"
+    assert mapping.target_id == "TopVolantis"
+
+
+def test_fmu_identifier_mapping_rejects_same_system_alias_mapping_to_itself() -> None:
+    """Same-system aliases must point to a different identifier."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Same-system alias mapping must have different source_id and "
+            "target_id; use relation_type='primary' if they should match"
+        ),
+    ):
+        create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.rms,
+            relation_type=FMURelationType.alias,
+            source_id="TopVolantis",
+            target_id="TopVolantis",
+        )
+
+
+def test_fmu_identifier_mapping_rejects_same_system_unmappable() -> None:
+    """Unmappable relations are not valid for same-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Same-system mapping cannot use relation_type 'unmappable'",
+    ):
+        FMUIdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.rms,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=FMURelationType.unmappable,
+            source_id="NoMatch",
+        )
+
+
+def test_fmu_identifier_mapping_rejects_cross_system_alias() -> None:
+    """Alias relations are not valid for internal .fmu cross-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Cross-system mapping cannot use relation_type 'alias'",
+    ):
+        create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            relation_type=FMURelationType.alias,
+            source_id="TOP_VOLANTIS",
+            target_id="VOLANTIS GP. Top",
+        )
+
+
+def test_fmu_identifier_mapping_allows_unmappable_without_target() -> None:
+    """An unmappable relation can omit target identifier fields."""
+    mapping = FMUIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        mapping_type=MappingType.stratigraphy,
+        relation_type=FMURelationType.unmappable,
+        source_id="NoMatch",
+    )
+
+    assert mapping.target_id is None
+    assert mapping.target_uuid is None
+
+
+def test_fmu_identifier_mapping_allows_explicit_none_target_for_unmappable() -> None:
+    """An unmappable relation also accepts an explicit null target identifier."""
+    mapping = FMUIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        mapping_type=MappingType.stratigraphy,
+        relation_type=FMURelationType.unmappable,
+        source_id="NoMatch",
+        target_id=None,
+    )
+
+    assert mapping.target_id is None
+
+
+def test_fmu_identifier_mapping_rejects_blank_target_id() -> None:
+    """Target identifiers cannot be blank when provided."""
+    with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
+        create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            relation_type=FMURelationType.primary,
+            source_id="TopVolantis",
+            target_id="   ",
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_system", "relation_type"),
+    [
+        (DataSystem.rms, FMURelationType.primary),
+        (DataSystem.rms, FMURelationType.alias),
+        (DataSystem.smda, FMURelationType.primary),
+    ],
+)
+def test_fmu_identifier_mapping_requires_target_id_for_non_unmappable_relations(
+    target_system: DataSystem,
+    relation_type: FMURelationType,
+) -> None:
+    """All non-unmappable mappings require a target identifier."""
+    with pytest.raises(
+        ValueError,
+        match="target_id is required unless relation_type is 'unmappable'",
+    ):
+        FMUIdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=target_system,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=relation_type,
+            source_id="TopVolantis",
+        )
+
+
+def test_fmu_identifier_mapping_rejects_target_for_unmappable_relation() -> None:
+    """Unmappable relations must not carry target identifier fields."""
+    with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
+        FMUIdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=FMURelationType.unmappable,
+            source_id="NoMatch",
+            target_id="VOLANTIS GP. Top",
+        )
+
+
+def test_fmu_identifier_mapping_rejects_target_uuid_for_unmappable_relation() -> None:
+    """Unmappable relations must not carry target UUID fields."""
+    with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
+        FMUIdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=FMURelationType.unmappable,
+            source_id="NoMatch",
+            target_uuid=uuid4(),
+        )
+
+
+def test_fmu_mappings_defaults_to_empty_collections() -> None:
+    """The .fmu mappings file model defaults to empty mapping collections."""
+    mappings = FMUMappings()
+
+    assert mappings.stratigraphy == FMUStratigraphyMappings(root=[])
+    assert mappings.wellbore == FMUWellboreMappings(root=[])
+
+
+def test_fmu_stratigraphy_mappings_allow_empty_collection() -> None:
+    """Stratigraphy collections can be empty when no mappings exist yet."""
+    mappings = FMUStratigraphyMappings(root=[])
+
+    assert list(mappings) == []
+    assert len(mappings) == 0
+
+
+def test_fmu_stratigraphy_mappings_allow_valid_collection() -> None:
+    """Stratigraphy collections allow valid mappings."""
+    primary = create_stratigraphy_mapping()
+    alias = create_stratigraphy_mapping(
+        relation_type=FMURelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+    mapped = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        target_id="VOLANTIS GP. Top",
+    )
+    mappings = FMUStratigraphyMappings(root=[primary, alias, mapped])
+    expected = [primary, alias, mapped]
+
+    assert mappings.root == expected
+
+
+def test_fmu_stratigraphy_mappings_support_dunder_methods() -> None:
+    """Stratigraphy collections support the expected dunder methods."""
+    primary = create_stratigraphy_mapping()
+    alias = create_stratigraphy_mapping(
+        relation_type=FMURelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+    mapped = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        target_id="VOLANTIS GP. Top",
+    )
+    mappings = FMUStratigraphyMappings(root=[primary, alias, mapped])
+    expected = [primary, alias, mapped]
+
+    assert mappings[0] == primary
+    assert list(mappings) == expected
+    assert len(mappings) == len(expected)
+
+
+def test_fmu_stratigraphy_mappings_serializes_to_json_list() -> None:
+    """FMUStratigraphyMappings serializes as a root list."""
+    mappings = FMUStratigraphyMappings(root=[create_stratigraphy_mapping()])
+
+    assert mappings.model_dump(mode="json", exclude_none=True) == [
+        {
+            "source_system": "rms",
+            "target_system": "rms",
+            "mapping_type": "stratigraphy",
+            "relation_type": "primary",
+            "source_id": "TopVolantis",
+            "target_id": "TopVolantis",
+        }
+    ]
+
+
+def test_fmu_stratigraphy_mappings_reject_alias_without_primary() -> None:
+    """Same-system aliases must point to an existing same-system primary."""
+    alias = create_stratigraphy_mapping(
+        relation_type=FMURelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Same-system alias mappings must point to an existing "
+            "same-system primary source_id"
+        ),
+    ):
+        FMUStratigraphyMappings(root=[alias])
+
+
+def test_fmu_stratigraphy_mappings_reject_cross_system_alias_sources() -> None:
+    """Cross-system mappings must use same-system primary source identifiers."""
+    primary = create_stratigraphy_mapping()
+    alias = create_stratigraphy_mapping(
+        relation_type=FMURelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+    mapped_alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=FMURelationType.primary,
+        source_id="TOP_VOLANTIS",
+        target_id="VOLANTIS GP. Top",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cross-system mappings must use a source_id that is defined "
+            "as a same-system primary"
+        ),
+    ):
+        FMUStratigraphyMappings(root=[primary, alias, mapped_alias])
+
+
+def test_fmu_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
+    """A same-system primary identifier can only have one outcome per target system."""
+    primary = create_stratigraphy_mapping()
+    mapped = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=FMURelationType.primary,
+        source_id="TopVolantis",
+        target_id="VOLANTIS GP. Top",
+    )
+    unmappable = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=FMURelationType.unmappable,
+        source_id="TopVolantis",
+        target_id=None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=("A source_id can only have one cross-system mapping per target system"),
+    ):
+        FMUStratigraphyMappings(root=[primary, mapped, unmappable])
+
+
+def test_fmu_stratigraphy_mappings_reject_reused_same_system_source_id() -> None:
+    """A source_id cannot be both a primary and an alias in the same collection."""
+    primary = create_stratigraphy_mapping()
+    other_primary = create_stratigraphy_mapping(
+        source_id="TopVolon",
+        target_id="TopVolon",
+    )
+    conflicting_alias = create_stratigraphy_mapping(
+        relation_type=FMURelationType.alias,
+        source_id="TopVolantis",
+        target_id="TopVolon",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=("Same-system mappings cannot reuse the same source_id"),
+    ):
+        FMUStratigraphyMappings(root=[primary, other_primary, conflicting_alias])
+
+
+@pytest.mark.parametrize(
+    ("target_system", "target_id"),
+    [
+        (DataSystem.simulator, "B21C"),
+        (DataSystem.smda, "NO 30/9-B-21 C"),
+        (DataSystem.pdm, "30/9-B-21 C"),
+    ],
+)
+def test_fmu_wellbore_mapping_supports_expected_target_systems(
+    target_system: DataSystem, target_id: str
+) -> None:
+    """Ensure wellbore mappings can target the supported systems."""
+    mapping = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=target_system,
+        relation_type=FMURelationType.primary,
+        source_id="30_9-B-21_C",
+        target_id=target_id,
+    )
+
+    assert mapping.target_system == target_system
+    assert mapping.target_id == target_id
+
+
+def test_fmu_wellbore_mappings_allow_empty_collection() -> None:
+    """Wellbore collections can be empty when no mappings exist yet."""
+    mappings = FMUWellboreMappings(root=[])
+
+    assert list(mappings) == []
+    assert len(mappings) == 0
+
+
+def test_fmu_wellbore_mappings_allow_valid_collection() -> None:
+    """Wellbore collections allow valid mappings."""
+    primary = create_wellbore_mapping()
+    simulator_target = create_wellbore_mapping(
         target_system=DataSystem.simulator,
+        target_id="B21C",
+    )
+    pdm_target = create_wellbore_mapping(
+        target_system=DataSystem.pdm,
+        target_id="30/9-B-21 C",
+    )
+    mappings = FMUWellboreMappings(root=[primary, simulator_target, pdm_target])
+    expected = [primary, simulator_target, pdm_target]
+
+    assert mappings.root == expected
+
+
+def test_fmu_wellbore_mappings_support_dunder_methods() -> None:
+    """Wellbore collections support the expected dunder methods."""
+    primary = create_wellbore_mapping()
+    simulator_target = create_wellbore_mapping(
+        target_system=DataSystem.simulator,
+        target_id="B21C",
+    )
+    pdm_target = create_wellbore_mapping(
+        target_system=DataSystem.pdm,
+        target_id="30/9-B-21 C",
+    )
+    mappings = FMUWellboreMappings(root=[primary, simulator_target, pdm_target])
+    expected = [primary, simulator_target, pdm_target]
+
+    assert mappings[0] == primary
+    assert list(mappings) == expected
+    assert len(mappings) == len(expected)
+
+
+def test_fmu_stratigraphy_mappings_converts_to_datamodels_mappings() -> None:
+    """Internal .fmu mappings convert to fmu-datamodels StratigraphyMappings."""
+    mappings = FMUStratigraphyMappings(
+        root=[
+            create_stratigraphy_mapping(),
+            create_stratigraphy_mapping(
+                source_id="TopVOLANTIS",
+                target_id="TopVolantis",
+                relation_type=FMURelationType.alias,
+            ),
+            create_stratigraphy_mapping(
+                target_id="VOLANTIS GP. Top",
+                target_system=DataSystem.smda,
+            ),
+            create_stratigraphy_mapping(source_id="Seabase", target_id="Seabase"),
+            create_stratigraphy_mapping(
+                source_id="Seabase",
+                target_id=None,
+                relation_type=FMURelationType.unmappable,
+                target_system=DataSystem.smda,
+            ),
+        ]
     )
 
-    with pytest.raises(ValidationError, match="target_system"):
-        MappingGroup(
-            target_id="Viking GP.",
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
-            source_system=DataSystem.rms,
-            mappings=[primary, different_target_system],
-        )
+    converted = mappings.to_stratigraphy_mappings()
+
+    assert isinstance(converted, StratigraphyMappings)
+    assert converted.model_dump(mode="json", exclude_none=True) == [
+        {
+            "source_system": "rms",
+            "target_system": "smda",
+            "mapping_type": "stratigraphy",
+            "relation_type": "primary",
+            "source_id": "TopVolantis",
+            "target_id": "VOLANTIS GP. Top",
+        },
+        {
+            "source_system": "rms",
+            "target_system": "smda",
+            "mapping_type": "stratigraphy",
+            "relation_type": "alias",
+            "source_id": "TopVOLANTIS",
+            "target_id": "VOLANTIS GP. Top",
+        },
+    ]
 
 
-def test_mapping_group_requires_shared_source_system() -> None:
-    """All mappings must share the group source_system."""
-    primary = _make_mapping("Viking Gp", "Viking GP.", RelationType.primary)
-    different_source_system = _make_mapping(
-        "Viking Gp 2",
-        "Viking GP.",
-        RelationType.alias,
-        source_system=DataSystem.simulator,
+def test_fmu_wellbore_mappings_converts_to_datamodels_mappings() -> None:
+    """Internal .fmu mappings convert to fmu-datamodels WellboreMappings."""
+    mappings = FMUWellboreMappings(
+        root=[
+            create_wellbore_mapping(),
+            create_wellbore_mapping(
+                source_id="30_9-B-21C",
+                target_id="30_9-B-21_C",
+                relation_type=FMURelationType.alias,
+            ),
+            create_wellbore_mapping(
+                target_system=DataSystem.simulator,
+                target_id="B21C",
+            ),
+        ]
     )
 
-    with pytest.raises(ValidationError, match="source_system"):
-        MappingGroup(
-            target_id="Viking GP.",
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
-            source_system=DataSystem.rms,
-            mappings=[primary, different_source_system],
-        )
+    converted = mappings.to_wellbore_mappings()
+
+    assert isinstance(converted, WellboreMappings)
+    assert converted.model_dump(mode="json", exclude_none=True) == [
+        {
+            "source_system": "rms",
+            "target_system": "simulator",
+            "mapping_type": "wellbore",
+            "relation_type": "primary",
+            "source_id": "30_9-B-21_C",
+            "target_id": "B21C",
+        },
+        {
+            "source_system": "rms",
+            "target_system": "simulator",
+            "mapping_type": "wellbore",
+            "relation_type": "alias",
+            "source_id": "30_9-B-21C",
+            "target_id": "B21C",
+        },
+    ]

--- a/tests/test_mappings_model.py
+++ b/tests/test_mappings_model.py
@@ -1,15 +1,18 @@
 """Tests for validators in the .fmu mapping models."""
 
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
 from fmu.datamodels.context.mappings import (
     DataSystem,
     MappingType,
+    RelationType,
     StratigraphyMappings,
     WellboreMappings,
 )
 
+import fmu.settings.models.mappings as mappings_model
 from fmu.settings.models.mappings import (
     InternalBaseMapping,
     InternalIdentifierMapping,
@@ -406,7 +409,27 @@ def test_internal_stratigraphy_mappings_serializes_to_json_list() -> None:
     ]
 
 
-def test_internal_stratigraphy_mappings_reject_alias_without_primary() -> None:
+def test_internal_stratigraphy_mappings_validates_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """InternalStratigraphyMappings validates mappings through the shared helper."""
+    mapping = create_stratigraphy_mapping()
+    validate_collection = Mock()
+
+    monkeypatch.setattr(
+        mappings_model,
+        "_validate_identifier_mappings_collection",
+        validate_collection,
+    )
+
+    InternalStratigraphyMappings(root=[mapping])
+
+    validate_collection.assert_called_once_with([mapping])
+
+
+def test_validate_identifier_mappings_collection_rejects_alias_without_primary() -> (
+    None
+):
     """Same-system aliases must point to an existing same-system primary."""
     alias = create_stratigraphy_mapping(
         relation_type=InternalRelationType.alias,
@@ -421,10 +444,10 @@ def test_internal_stratigraphy_mappings_reject_alias_without_primary() -> None:
             "same-system primary source_id"
         ),
     ):
-        InternalStratigraphyMappings(root=[alias])
+        mappings_model._validate_identifier_mappings_collection([alias])
 
 
-def test_internal_stratigraphy_mappings_reject_cross_system_alias_sources() -> None:
+def test_validate_collection_rejects_cross_system_alias_sources() -> None:
     """Cross-system mappings must use same-system primary source identifiers."""
     primary = create_stratigraphy_mapping()
     alias = create_stratigraphy_mapping(
@@ -447,10 +470,12 @@ def test_internal_stratigraphy_mappings_reject_cross_system_alias_sources() -> N
             "as a same-system primary"
         ),
     ):
-        InternalStratigraphyMappings(root=[primary, alias, mapped_alias])
+        mappings_model._validate_identifier_mappings_collection(
+            [primary, alias, mapped_alias]
+        )
 
 
-def test_internal_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
+def test_validate_collection_rejects_multiple_cross_system_outcomes() -> None:
     """A same-system primary identifier can only have one outcome per target system."""
     primary = create_stratigraphy_mapping()
     mapped = create_stratigraphy_mapping(
@@ -472,10 +497,12 @@ def test_internal_stratigraphy_mappings_reject_multiple_cross_system_outcomes() 
         ValueError,
         match=("A source_id can only have one cross-system mapping per target system"),
     ):
-        InternalStratigraphyMappings(root=[primary, mapped, unmappable])
+        mappings_model._validate_identifier_mappings_collection(
+            [primary, mapped, unmappable]
+        )
 
 
-def test_internal_stratigraphy_mappings_reject_reused_same_system_source_id() -> None:
+def test_validate_collection_rejects_reused_same_system_source_id() -> None:
     """A source_id cannot be both a primary and an alias in the same collection."""
     primary = create_stratigraphy_mapping()
     other_primary = create_stratigraphy_mapping(
@@ -492,7 +519,28 @@ def test_internal_stratigraphy_mappings_reject_reused_same_system_source_id() ->
         ValueError,
         match=("Same-system mappings cannot reuse the same source_id"),
     ):
-        InternalStratigraphyMappings(root=[primary, other_primary, conflicting_alias])
+        mappings_model._validate_identifier_mappings_collection(
+            [primary, other_primary, conflicting_alias]
+        )
+
+
+def test_validate_identifier_mappings_collection_allows_multiple_target_systems() -> (
+    None
+):
+    """A primary source identifier can map once to each target system."""
+    primary = create_stratigraphy_mapping()
+    smda_mapping = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        target_id="VOLANTIS GP. Top",
+    )
+    simulator_mapping = create_stratigraphy_mapping(
+        target_system=DataSystem.simulator,
+        target_id="TopVolantis",
+    )
+
+    mappings_model._validate_identifier_mappings_collection(
+        [primary, smda_mapping, simulator_mapping]
+    )
 
 
 @pytest.mark.parametrize(
@@ -561,6 +609,123 @@ def test_internal_wellbore_mappings_support_dunder_methods() -> None:
     assert mappings[0] == primary
     assert list(mappings) == expected
     assert len(mappings) == len(expected)
+
+
+def test_to_datamodels_identifier_mapping_payloads_drops_internal_only_mappings() -> (
+    None
+):
+    """Only cross-system primary mappings are returned as datamodels payloads."""
+    primary = create_stratigraphy_mapping()
+    alias = create_stratigraphy_mapping(
+        source_id="TopVOLANTIS",
+        target_id="TopVolantis",
+        relation_type=InternalRelationType.alias,
+    )
+    unmappable = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        target_id=None,
+        relation_type=InternalRelationType.unmappable,
+    )
+
+    payloads = mappings_model._to_datamodels_identifier_mapping_payloads(
+        [primary, alias, unmappable]
+    )
+
+    assert payloads == []
+
+
+def test_to_datamodels_identifier_mapping_payloads_expands_aliases_to_targets() -> None:
+    """Same-system aliases are expanded to matching cross-system primary mappings."""
+    primary = create_stratigraphy_mapping()
+    alias = create_stratigraphy_mapping(
+        source_id="TopVOLANTIS",
+        target_id="TopVolantis",
+        relation_type=InternalRelationType.alias,
+    )
+    smda_mapping = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        target_id="VOLANTIS GP. Top",
+    )
+    simulator_mapping = create_stratigraphy_mapping(
+        target_system=DataSystem.simulator,
+        target_id="TopVolantis",
+    )
+
+    payloads = mappings_model._to_datamodels_identifier_mapping_payloads(
+        [primary, alias, smda_mapping, simulator_mapping]
+    )
+
+    assert payloads == [
+        {
+            "source_system": DataSystem.rms,
+            "target_system": DataSystem.smda,
+            "mapping_type": MappingType.stratigraphy,
+            "relation_type": RelationType.primary,
+            "source_id": "TopVolantis",
+            "source_uuid": None,
+            "target_id": "VOLANTIS GP. Top",
+            "target_uuid": None,
+        },
+        {
+            "source_system": DataSystem.rms,
+            "target_system": DataSystem.smda,
+            "mapping_type": MappingType.stratigraphy,
+            "relation_type": RelationType.alias,
+            "source_id": "TopVOLANTIS",
+            "source_uuid": None,
+            "target_id": "VOLANTIS GP. Top",
+            "target_uuid": None,
+        },
+        {
+            "source_system": DataSystem.rms,
+            "target_system": DataSystem.simulator,
+            "mapping_type": MappingType.stratigraphy,
+            "relation_type": RelationType.primary,
+            "source_id": "TopVolantis",
+            "source_uuid": None,
+            "target_id": "TopVolantis",
+            "target_uuid": None,
+        },
+        {
+            "source_system": DataSystem.rms,
+            "target_system": DataSystem.simulator,
+            "mapping_type": MappingType.stratigraphy,
+            "relation_type": RelationType.alias,
+            "source_id": "TopVOLANTIS",
+            "source_uuid": None,
+            "target_id": "TopVolantis",
+            "target_uuid": None,
+        },
+    ]
+
+
+def test_to_datamodels_identifier_mapping_payloads_preserves_relevant_uuids() -> None:
+    """Alias payloads use the alias source UUID and cross-system target UUID."""
+    alias_source_uuid = uuid4()
+    target_uuid = uuid4()
+    alias = InternalStratigraphyIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        relation_type=InternalRelationType.alias,
+        source_id="TopVOLANTIS",
+        source_uuid=alias_source_uuid,
+        target_id="TopVolantis",
+    )
+    smda_mapping = InternalStratigraphyIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=InternalRelationType.primary,
+        source_id="TopVolantis",
+        target_id="VOLANTIS GP. Top",
+        target_uuid=target_uuid,
+    )
+
+    payloads = mappings_model._to_datamodels_identifier_mapping_payloads(
+        [alias, smda_mapping]
+    )
+
+    assert payloads[1]["source_uuid"] == alias_source_uuid
+    assert payloads[1]["target_uuid"] == target_uuid
 
 
 def test_internal_stratigraphy_mappings_converts_to_datamodels_mappings() -> None:

--- a/tests/test_mappings_model.py
+++ b/tests/test_mappings_model.py
@@ -11,14 +11,14 @@ from fmu.datamodels.context.mappings import (
 )
 
 from fmu.settings.models.mappings import (
-    FMUBaseMapping,
-    FMUIdentifierMapping,
-    FMUMappings,
-    FMURelationType,
-    FMUStratigraphyIdentifierMapping,
-    FMUStratigraphyMappings,
-    FMUWellboreIdentifierMapping,
-    FMUWellboreMappings,
+    InternalBaseMapping,
+    InternalIdentifierMapping,
+    InternalMappings,
+    InternalRelationType,
+    InternalStratigraphyIdentifierMapping,
+    InternalStratigraphyMappings,
+    InternalWellboreIdentifierMapping,
+    InternalWellboreMappings,
 )
 
 
@@ -26,12 +26,12 @@ def create_stratigraphy_mapping(
     *,
     source_system: DataSystem = DataSystem.rms,
     target_system: DataSystem = DataSystem.rms,
-    relation_type: FMURelationType = FMURelationType.primary,
+    relation_type: InternalRelationType = InternalRelationType.primary,
     source_id: str = "TopVolantis",
     target_id: str | None = "TopVolantis",
-) -> FMUStratigraphyIdentifierMapping:
+) -> InternalStratigraphyIdentifierMapping:
     """Build an internal .fmu stratigraphy mapping with sensible defaults."""
-    return FMUStratigraphyIdentifierMapping(
+    return InternalStratigraphyIdentifierMapping(
         source_system=source_system,
         target_system=target_system,
         relation_type=relation_type,
@@ -44,12 +44,12 @@ def create_wellbore_mapping(
     *,
     source_system: DataSystem = DataSystem.rms,
     target_system: DataSystem = DataSystem.rms,
-    relation_type: FMURelationType = FMURelationType.primary,
+    relation_type: InternalRelationType = InternalRelationType.primary,
     source_id: str = "30_9-B-21_C",
     target_id: str | None = "30_9-B-21_C",
-) -> FMUWellboreIdentifierMapping:
+) -> InternalWellboreIdentifierMapping:
     """Build an internal .fmu wellbore mapping with sensible defaults."""
-    return FMUWellboreIdentifierMapping(
+    return InternalWellboreIdentifierMapping(
         source_system=source_system,
         target_system=target_system,
         relation_type=relation_type,
@@ -59,13 +59,13 @@ def create_wellbore_mapping(
 
 
 @pytest.mark.parametrize(
-    "relation_type", [FMURelationType.primary, FMURelationType.alias]
+    "relation_type", [InternalRelationType.primary, InternalRelationType.alias]
 )
-def test_fmu_base_mapping_allows_same_system_primary_and_alias(
-    relation_type: FMURelationType,
+def test_internal_base_mapping_allows_same_system_primary_and_alias(
+    relation_type: InternalRelationType,
 ) -> None:
     """Same-system primary and alias relations are allowed."""
-    FMUBaseMapping(
+    InternalBaseMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.rms,
         mapping_type=MappingType.stratigraphy,
@@ -74,13 +74,13 @@ def test_fmu_base_mapping_allows_same_system_primary_and_alias(
 
 
 @pytest.mark.parametrize(
-    "relation_type", [FMURelationType.primary, FMURelationType.unmappable]
+    "relation_type", [InternalRelationType.primary, InternalRelationType.unmappable]
 )
-def test_fmu_base_mapping_allows_cross_system_primary_and_unmappable(
-    relation_type: FMURelationType,
+def test_internal_base_mapping_allows_cross_system_primary_and_unmappable(
+    relation_type: InternalRelationType,
 ) -> None:
     """Cross-system primary and unmappable relations are allowed."""
-    FMUBaseMapping(
+    InternalBaseMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
         mapping_type=MappingType.stratigraphy,
@@ -88,53 +88,53 @@ def test_fmu_base_mapping_allows_cross_system_primary_and_unmappable(
     )
 
 
-def test_fmu_base_mapping_rejects_same_system_unmappable() -> None:
+def test_internal_base_mapping_rejects_same_system_unmappable() -> None:
     """Unmappable is only valid for cross-system mappings."""
     with pytest.raises(
         ValueError,
         match="Same-system mapping cannot use relation_type 'unmappable'",
     ):
-        FMUBaseMapping(
+        InternalBaseMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.rms,
             mapping_type=MappingType.stratigraphy,
-            relation_type=FMURelationType.unmappable,
+            relation_type=InternalRelationType.unmappable,
         )
 
 
-def test_fmu_base_mapping_rejects_cross_system_alias() -> None:
+def test_internal_base_mapping_rejects_cross_system_alias() -> None:
     """Alias is only valid for same-system mappings."""
     with pytest.raises(
         ValueError,
         match="Cross-system mapping cannot use relation_type 'alias'",
     ):
-        FMUBaseMapping(
+        InternalBaseMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.smda,
             mapping_type=MappingType.stratigraphy,
-            relation_type=FMURelationType.alias,
+            relation_type=InternalRelationType.alias,
         )
 
 
-def test_fmu_identifier_mapping_ids_not_empty_strings() -> None:
+def test_internal_identifier_mapping_ids_not_empty_strings() -> None:
     """Ensure that validation fails if a mapping identifier is an empty string."""
     with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
-        FMUIdentifierMapping(
+        InternalIdentifierMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.smda,
             mapping_type=MappingType.stratigraphy,
-            relation_type=FMURelationType.primary,
+            relation_type=InternalRelationType.primary,
             source_id="",
             target_id="foo",
         )
 
 
-def test_fmu_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
+def test_internal_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
     """Source and target identifiers are stripped when they contain padding."""
     mapping = create_stratigraphy_mapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
-        relation_type=FMURelationType.primary,
+        relation_type=InternalRelationType.primary,
         source_id="  TopVolantis  ",
         target_id="  VOLANTIS GP. Top  ",
     )
@@ -143,12 +143,14 @@ def test_fmu_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None
     assert mapping.target_id == "VOLANTIS GP. Top"
 
 
-def test_fmu_identifier_mapping_allows_same_system_primary_mapping_to_itself() -> None:
+def test_internal_identifier_mapping_allows_same_system_primary_mapping_to_itself() -> (
+    None
+):
     """Same-system primary mappings must map an identifier to itself."""
     mapping = create_stratigraphy_mapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.rms,
-        relation_type=FMURelationType.primary,
+        relation_type=InternalRelationType.primary,
         source_id="TopVolantis",
         target_id="TopVolantis",
     )
@@ -156,7 +158,7 @@ def test_fmu_identifier_mapping_allows_same_system_primary_mapping_to_itself() -
     assert mapping.source_id == mapping.target_id
 
 
-def test_fmu_identifier_mapping_rejects_same_system_primary_to_other_id() -> None:
+def test_internal_identifier_mapping_rejects_same_system_primary_to_other_id() -> None:
     """Same-system primary mappings cannot map an identifier to another one."""
     with pytest.raises(
         ValueError,
@@ -168,18 +170,18 @@ def test_fmu_identifier_mapping_rejects_same_system_primary_to_other_id() -> Non
         create_stratigraphy_mapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.rms,
-            relation_type=FMURelationType.primary,
+            relation_type=InternalRelationType.primary,
             source_id="TopVolantis",
             target_id="TopVolon",
         )
 
 
-def test_fmu_identifier_mapping_allows_same_system_alias() -> None:
+def test_internal_identifier_mapping_allows_same_system_alias() -> None:
     """Same-system aliases can point to a primary identifier."""
     mapping = create_stratigraphy_mapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.rms,
-        relation_type=FMURelationType.alias,
+        relation_type=InternalRelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
@@ -188,7 +190,9 @@ def test_fmu_identifier_mapping_allows_same_system_alias() -> None:
     assert mapping.target_id == "TopVolantis"
 
 
-def test_fmu_identifier_mapping_rejects_same_system_alias_mapping_to_itself() -> None:
+def test_internal_identifier_mapping_rejects_same_system_alias_mapping_to_itself() -> (
+    None
+):
     """Same-system aliases must point to a different identifier."""
     with pytest.raises(
         ValueError,
@@ -200,28 +204,28 @@ def test_fmu_identifier_mapping_rejects_same_system_alias_mapping_to_itself() ->
         create_stratigraphy_mapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.rms,
-            relation_type=FMURelationType.alias,
+            relation_type=InternalRelationType.alias,
             source_id="TopVolantis",
             target_id="TopVolantis",
         )
 
 
-def test_fmu_identifier_mapping_rejects_same_system_unmappable() -> None:
+def test_internal_identifier_mapping_rejects_same_system_unmappable() -> None:
     """Unmappable relations are not valid for same-system mappings."""
     with pytest.raises(
         ValueError,
         match="Same-system mapping cannot use relation_type 'unmappable'",
     ):
-        FMUIdentifierMapping(
+        InternalIdentifierMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.rms,
             mapping_type=MappingType.stratigraphy,
-            relation_type=FMURelationType.unmappable,
+            relation_type=InternalRelationType.unmappable,
             source_id="NoMatch",
         )
 
 
-def test_fmu_identifier_mapping_rejects_cross_system_alias() -> None:
+def test_internal_identifier_mapping_rejects_cross_system_alias() -> None:
     """Alias relations are not valid for internal .fmu cross-system mappings."""
     with pytest.raises(
         ValueError,
@@ -230,19 +234,19 @@ def test_fmu_identifier_mapping_rejects_cross_system_alias() -> None:
         create_stratigraphy_mapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.smda,
-            relation_type=FMURelationType.alias,
+            relation_type=InternalRelationType.alias,
             source_id="TOP_VOLANTIS",
             target_id="VOLANTIS GP. Top",
         )
 
 
-def test_fmu_identifier_mapping_allows_unmappable_without_target() -> None:
+def test_internal_identifier_mapping_allows_unmappable_without_target() -> None:
     """An unmappable relation can omit target identifier fields."""
-    mapping = FMUIdentifierMapping(
+    mapping = InternalIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
         mapping_type=MappingType.stratigraphy,
-        relation_type=FMURelationType.unmappable,
+        relation_type=InternalRelationType.unmappable,
         source_id="NoMatch",
     )
 
@@ -250,13 +254,15 @@ def test_fmu_identifier_mapping_allows_unmappable_without_target() -> None:
     assert mapping.target_uuid is None
 
 
-def test_fmu_identifier_mapping_allows_explicit_none_target_for_unmappable() -> None:
+def test_internal_identifier_mapping_allows_explicit_none_target_for_unmappable() -> (
+    None
+):
     """An unmappable relation also accepts an explicit null target identifier."""
-    mapping = FMUIdentifierMapping(
+    mapping = InternalIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
         mapping_type=MappingType.stratigraphy,
-        relation_type=FMURelationType.unmappable,
+        relation_type=InternalRelationType.unmappable,
         source_id="NoMatch",
         target_id=None,
     )
@@ -264,13 +270,13 @@ def test_fmu_identifier_mapping_allows_explicit_none_target_for_unmappable() -> 
     assert mapping.target_id is None
 
 
-def test_fmu_identifier_mapping_rejects_blank_target_id() -> None:
+def test_internal_identifier_mapping_rejects_blank_target_id() -> None:
     """Target identifiers cannot be blank when provided."""
     with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
         create_stratigraphy_mapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.smda,
-            relation_type=FMURelationType.primary,
+            relation_type=InternalRelationType.primary,
             source_id="TopVolantis",
             target_id="   ",
         )
@@ -279,21 +285,21 @@ def test_fmu_identifier_mapping_rejects_blank_target_id() -> None:
 @pytest.mark.parametrize(
     ("target_system", "relation_type"),
     [
-        (DataSystem.rms, FMURelationType.primary),
-        (DataSystem.rms, FMURelationType.alias),
-        (DataSystem.smda, FMURelationType.primary),
+        (DataSystem.rms, InternalRelationType.primary),
+        (DataSystem.rms, InternalRelationType.alias),
+        (DataSystem.smda, InternalRelationType.primary),
     ],
 )
-def test_fmu_identifier_mapping_requires_target_id_for_non_unmappable_relations(
+def test_internal_identifier_mapping_requires_target_id_for_non_unmappable_relations(
     target_system: DataSystem,
-    relation_type: FMURelationType,
+    relation_type: InternalRelationType,
 ) -> None:
     """All non-unmappable mappings require a target identifier."""
     with pytest.raises(
         ValueError,
         match="target_id is required unless relation_type is 'unmappable'",
     ):
-        FMUIdentifierMapping(
+        InternalIdentifierMapping(
             source_system=DataSystem.rms,
             target_system=target_system,
             mapping_type=MappingType.stratigraphy,
@@ -302,53 +308,55 @@ def test_fmu_identifier_mapping_requires_target_id_for_non_unmappable_relations(
         )
 
 
-def test_fmu_identifier_mapping_rejects_target_for_unmappable_relation() -> None:
+def test_internal_identifier_mapping_rejects_target_for_unmappable_relation() -> None:
     """Unmappable relations must not carry target identifier fields."""
     with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
-        FMUIdentifierMapping(
+        InternalIdentifierMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.smda,
             mapping_type=MappingType.stratigraphy,
-            relation_type=FMURelationType.unmappable,
+            relation_type=InternalRelationType.unmappable,
             source_id="NoMatch",
             target_id="VOLANTIS GP. Top",
         )
 
 
-def test_fmu_identifier_mapping_rejects_target_uuid_for_unmappable_relation() -> None:
+def test_internal_identifier_mapping_rejects_target_uuid_for_unmappable_relation() -> (
+    None
+):
     """Unmappable relations must not carry target UUID fields."""
     with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
-        FMUIdentifierMapping(
+        InternalIdentifierMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.smda,
             mapping_type=MappingType.stratigraphy,
-            relation_type=FMURelationType.unmappable,
+            relation_type=InternalRelationType.unmappable,
             source_id="NoMatch",
             target_uuid=uuid4(),
         )
 
 
-def test_fmu_mappings_defaults_to_empty_collections() -> None:
+def test_internal_mappings_defaults_to_empty_collections() -> None:
     """The .fmu mappings file model defaults to empty mapping collections."""
-    mappings = FMUMappings()
+    mappings = InternalMappings()
 
-    assert mappings.stratigraphy == FMUStratigraphyMappings(root=[])
-    assert mappings.wellbore == FMUWellboreMappings(root=[])
+    assert mappings.stratigraphy == InternalStratigraphyMappings(root=[])
+    assert mappings.wellbore == InternalWellboreMappings(root=[])
 
 
-def test_fmu_stratigraphy_mappings_allow_empty_collection() -> None:
+def test_internal_stratigraphy_mappings_allow_empty_collection() -> None:
     """Stratigraphy collections can be empty when no mappings exist yet."""
-    mappings = FMUStratigraphyMappings(root=[])
+    mappings = InternalStratigraphyMappings(root=[])
 
     assert list(mappings) == []
     assert len(mappings) == 0
 
 
-def test_fmu_stratigraphy_mappings_allow_valid_collection() -> None:
+def test_internal_stratigraphy_mappings_allow_valid_collection() -> None:
     """Stratigraphy collections allow valid mappings."""
     primary = create_stratigraphy_mapping()
     alias = create_stratigraphy_mapping(
-        relation_type=FMURelationType.alias,
+        relation_type=InternalRelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
@@ -356,17 +364,17 @@ def test_fmu_stratigraphy_mappings_allow_valid_collection() -> None:
         target_system=DataSystem.smda,
         target_id="VOLANTIS GP. Top",
     )
-    mappings = FMUStratigraphyMappings(root=[primary, alias, mapped])
+    mappings = InternalStratigraphyMappings(root=[primary, alias, mapped])
     expected = [primary, alias, mapped]
 
     assert mappings.root == expected
 
 
-def test_fmu_stratigraphy_mappings_support_dunder_methods() -> None:
+def test_internal_stratigraphy_mappings_support_dunder_methods() -> None:
     """Stratigraphy collections support the expected dunder methods."""
     primary = create_stratigraphy_mapping()
     alias = create_stratigraphy_mapping(
-        relation_type=FMURelationType.alias,
+        relation_type=InternalRelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
@@ -374,7 +382,7 @@ def test_fmu_stratigraphy_mappings_support_dunder_methods() -> None:
         target_system=DataSystem.smda,
         target_id="VOLANTIS GP. Top",
     )
-    mappings = FMUStratigraphyMappings(root=[primary, alias, mapped])
+    mappings = InternalStratigraphyMappings(root=[primary, alias, mapped])
     expected = [primary, alias, mapped]
 
     assert mappings[0] == primary
@@ -382,9 +390,9 @@ def test_fmu_stratigraphy_mappings_support_dunder_methods() -> None:
     assert len(mappings) == len(expected)
 
 
-def test_fmu_stratigraphy_mappings_serializes_to_json_list() -> None:
-    """FMUStratigraphyMappings serializes as a root list."""
-    mappings = FMUStratigraphyMappings(root=[create_stratigraphy_mapping()])
+def test_internal_stratigraphy_mappings_serializes_to_json_list() -> None:
+    """InternalStratigraphyMappings serializes as a root list."""
+    mappings = InternalStratigraphyMappings(root=[create_stratigraphy_mapping()])
 
     assert mappings.model_dump(mode="json", exclude_none=True) == [
         {
@@ -398,10 +406,10 @@ def test_fmu_stratigraphy_mappings_serializes_to_json_list() -> None:
     ]
 
 
-def test_fmu_stratigraphy_mappings_reject_alias_without_primary() -> None:
+def test_internal_stratigraphy_mappings_reject_alias_without_primary() -> None:
     """Same-system aliases must point to an existing same-system primary."""
     alias = create_stratigraphy_mapping(
-        relation_type=FMURelationType.alias,
+        relation_type=InternalRelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
@@ -413,21 +421,21 @@ def test_fmu_stratigraphy_mappings_reject_alias_without_primary() -> None:
             "same-system primary source_id"
         ),
     ):
-        FMUStratigraphyMappings(root=[alias])
+        InternalStratigraphyMappings(root=[alias])
 
 
-def test_fmu_stratigraphy_mappings_reject_cross_system_alias_sources() -> None:
+def test_internal_stratigraphy_mappings_reject_cross_system_alias_sources() -> None:
     """Cross-system mappings must use same-system primary source identifiers."""
     primary = create_stratigraphy_mapping()
     alias = create_stratigraphy_mapping(
-        relation_type=FMURelationType.alias,
+        relation_type=InternalRelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
     mapped_alias = create_stratigraphy_mapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
-        relation_type=FMURelationType.primary,
+        relation_type=InternalRelationType.primary,
         source_id="TOP_VOLANTIS",
         target_id="VOLANTIS GP. Top",
     )
@@ -439,23 +447,23 @@ def test_fmu_stratigraphy_mappings_reject_cross_system_alias_sources() -> None:
             "as a same-system primary"
         ),
     ):
-        FMUStratigraphyMappings(root=[primary, alias, mapped_alias])
+        InternalStratigraphyMappings(root=[primary, alias, mapped_alias])
 
 
-def test_fmu_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
+def test_internal_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
     """A same-system primary identifier can only have one outcome per target system."""
     primary = create_stratigraphy_mapping()
     mapped = create_stratigraphy_mapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
-        relation_type=FMURelationType.primary,
+        relation_type=InternalRelationType.primary,
         source_id="TopVolantis",
         target_id="VOLANTIS GP. Top",
     )
     unmappable = create_stratigraphy_mapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
-        relation_type=FMURelationType.unmappable,
+        relation_type=InternalRelationType.unmappable,
         source_id="TopVolantis",
         target_id=None,
     )
@@ -464,10 +472,10 @@ def test_fmu_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> No
         ValueError,
         match=("A source_id can only have one cross-system mapping per target system"),
     ):
-        FMUStratigraphyMappings(root=[primary, mapped, unmappable])
+        InternalStratigraphyMappings(root=[primary, mapped, unmappable])
 
 
-def test_fmu_stratigraphy_mappings_reject_reused_same_system_source_id() -> None:
+def test_internal_stratigraphy_mappings_reject_reused_same_system_source_id() -> None:
     """A source_id cannot be both a primary and an alias in the same collection."""
     primary = create_stratigraphy_mapping()
     other_primary = create_stratigraphy_mapping(
@@ -475,7 +483,7 @@ def test_fmu_stratigraphy_mappings_reject_reused_same_system_source_id() -> None
         target_id="TopVolon",
     )
     conflicting_alias = create_stratigraphy_mapping(
-        relation_type=FMURelationType.alias,
+        relation_type=InternalRelationType.alias,
         source_id="TopVolantis",
         target_id="TopVolon",
     )
@@ -484,7 +492,7 @@ def test_fmu_stratigraphy_mappings_reject_reused_same_system_source_id() -> None
         ValueError,
         match=("Same-system mappings cannot reuse the same source_id"),
     ):
-        FMUStratigraphyMappings(root=[primary, other_primary, conflicting_alias])
+        InternalStratigraphyMappings(root=[primary, other_primary, conflicting_alias])
 
 
 @pytest.mark.parametrize(
@@ -495,14 +503,14 @@ def test_fmu_stratigraphy_mappings_reject_reused_same_system_source_id() -> None
         (DataSystem.pdm, "30/9-B-21 C"),
     ],
 )
-def test_fmu_wellbore_mapping_supports_expected_target_systems(
+def test_internal_wellbore_mapping_supports_expected_target_systems(
     target_system: DataSystem, target_id: str
 ) -> None:
     """Ensure wellbore mappings can target the supported systems."""
     mapping = create_wellbore_mapping(
         source_system=DataSystem.rms,
         target_system=target_system,
-        relation_type=FMURelationType.primary,
+        relation_type=InternalRelationType.primary,
         source_id="30_9-B-21_C",
         target_id=target_id,
     )
@@ -511,15 +519,15 @@ def test_fmu_wellbore_mapping_supports_expected_target_systems(
     assert mapping.target_id == target_id
 
 
-def test_fmu_wellbore_mappings_allow_empty_collection() -> None:
+def test_internal_wellbore_mappings_allow_empty_collection() -> None:
     """Wellbore collections can be empty when no mappings exist yet."""
-    mappings = FMUWellboreMappings(root=[])
+    mappings = InternalWellboreMappings(root=[])
 
     assert list(mappings) == []
     assert len(mappings) == 0
 
 
-def test_fmu_wellbore_mappings_allow_valid_collection() -> None:
+def test_internal_wellbore_mappings_allow_valid_collection() -> None:
     """Wellbore collections allow valid mappings."""
     primary = create_wellbore_mapping()
     simulator_target = create_wellbore_mapping(
@@ -530,13 +538,13 @@ def test_fmu_wellbore_mappings_allow_valid_collection() -> None:
         target_system=DataSystem.pdm,
         target_id="30/9-B-21 C",
     )
-    mappings = FMUWellboreMappings(root=[primary, simulator_target, pdm_target])
+    mappings = InternalWellboreMappings(root=[primary, simulator_target, pdm_target])
     expected = [primary, simulator_target, pdm_target]
 
     assert mappings.root == expected
 
 
-def test_fmu_wellbore_mappings_support_dunder_methods() -> None:
+def test_internal_wellbore_mappings_support_dunder_methods() -> None:
     """Wellbore collections support the expected dunder methods."""
     primary = create_wellbore_mapping()
     simulator_target = create_wellbore_mapping(
@@ -547,7 +555,7 @@ def test_fmu_wellbore_mappings_support_dunder_methods() -> None:
         target_system=DataSystem.pdm,
         target_id="30/9-B-21 C",
     )
-    mappings = FMUWellboreMappings(root=[primary, simulator_target, pdm_target])
+    mappings = InternalWellboreMappings(root=[primary, simulator_target, pdm_target])
     expected = [primary, simulator_target, pdm_target]
 
     assert mappings[0] == primary
@@ -555,15 +563,15 @@ def test_fmu_wellbore_mappings_support_dunder_methods() -> None:
     assert len(mappings) == len(expected)
 
 
-def test_fmu_stratigraphy_mappings_converts_to_datamodels_mappings() -> None:
+def test_internal_stratigraphy_mappings_converts_to_datamodels_mappings() -> None:
     """Internal .fmu mappings convert to fmu-datamodels StratigraphyMappings."""
-    mappings = FMUStratigraphyMappings(
+    mappings = InternalStratigraphyMappings(
         root=[
             create_stratigraphy_mapping(),
             create_stratigraphy_mapping(
                 source_id="TopVOLANTIS",
                 target_id="TopVolantis",
-                relation_type=FMURelationType.alias,
+                relation_type=InternalRelationType.alias,
             ),
             create_stratigraphy_mapping(
                 target_id="VOLANTIS GP. Top",
@@ -573,7 +581,7 @@ def test_fmu_stratigraphy_mappings_converts_to_datamodels_mappings() -> None:
             create_stratigraphy_mapping(
                 source_id="Seabase",
                 target_id=None,
-                relation_type=FMURelationType.unmappable,
+                relation_type=InternalRelationType.unmappable,
                 target_system=DataSystem.smda,
             ),
         ]
@@ -602,15 +610,15 @@ def test_fmu_stratigraphy_mappings_converts_to_datamodels_mappings() -> None:
     ]
 
 
-def test_fmu_wellbore_mappings_converts_to_datamodels_mappings() -> None:
+def test_internal_wellbore_mappings_converts_to_datamodels_mappings() -> None:
     """Internal .fmu mappings convert to fmu-datamodels WellboreMappings."""
-    mappings = FMUWellboreMappings(
+    mappings = InternalWellboreMappings(
         root=[
             create_wellbore_mapping(),
             create_wellbore_mapping(
                 source_id="30_9-B-21C",
                 target_id="30_9-B-21_C",
-                relation_type=FMURelationType.alias,
+                relation_type=InternalRelationType.alias,
             ),
             create_wellbore_mapping(
                 target_system=DataSystem.simulator,

--- a/tests/test_resources/test_mappings_manager.py
+++ b/tests/test_resources/test_mappings_manager.py
@@ -7,10 +7,7 @@ import pytest
 from fmu.datamodels.context.mappings import (
     DataSystem,
     MappingType,
-    RelationType,
-    StratigraphyIdentifierMapping,
     StratigraphyMappings,
-    WellboreIdentifierMapping,
     WellboreMappings,
 )
 
@@ -19,59 +16,96 @@ from fmu.settings._fmu_dir import ProjectFMUDirectory
 from fmu.settings._resources.mappings_manager import MappingsManager
 from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.diff import ListFieldDiff
-from fmu.settings.models.mappings import Mappings
+from fmu.settings.models.mappings import (
+    FMUMappings,
+    FMURelationType,
+    FMUStratigraphyIdentifierMapping,
+    FMUStratigraphyMappings,
+    FMUWellboreIdentifierMapping,
+    FMUWellboreMappings,
+)
 
 if TYPE_CHECKING:
     from fmu.settings.models.change_info import ChangeInfo
     from fmu.settings.models.log import Log
 
 
-@pytest.fixture
-def wellbore_mappings() -> WellboreMappings:
-    """Returns a valid WellboreMappings object."""
-    return WellboreMappings(
+def _stratigraphy_mappings(
+    source_id: str,
+    target_id: str,
+    *aliases: str,
+) -> FMUStratigraphyMappings:
+    return FMUStratigraphyMappings(
         root=[
-            WellboreIdentifierMapping(
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.rms,
+                relation_type=FMURelationType.primary,
+                source_id=source_id,
+                target_id=source_id,
+            ),
+            *[
+                FMUStratigraphyIdentifierMapping(
+                    source_system=DataSystem.rms,
+                    target_system=DataSystem.rms,
+                    relation_type=FMURelationType.alias,
+                    source_id=alias,
+                    target_id=source_id,
+                )
+                for alias in aliases
+            ],
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.smda,
+                relation_type=FMURelationType.primary,
+                source_id=source_id,
+                target_id=target_id,
+            ),
+        ]
+    )
+
+
+def _wellbore_mappings(source_id: str, target_id: str) -> FMUWellboreMappings:
+    return FMUWellboreMappings(
+        root=[
+            FMUWellboreIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.rms,
+                mapping_type=MappingType.wellbore,
+                relation_type=FMURelationType.primary,
+                source_id=source_id,
+                source_uuid=None,
+                target_id=source_id,
+                target_uuid=None,
+            ),
+            FMUWellboreIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.simulator,
                 mapping_type=MappingType.wellbore,
-                relation_type=RelationType.primary,
-                source_id="30_9-B-43_A",
+                relation_type=FMURelationType.primary,
+                source_id=source_id,
                 source_uuid=None,
-                target_id="B43A",
+                target_id=target_id,
                 target_uuid=None,
-            )
+            ),
         ]
     )
 
 
 @pytest.fixture
-def stratigraphy_mappings() -> StratigraphyMappings:
-    """Returns a valid StratigraphyMappings object."""
-    return StratigraphyMappings(
-        root=[
-            StratigraphyIdentifierMapping(
-                source_system=DataSystem.rms,
-                target_system=DataSystem.smda,
-                relation_type=RelationType.primary,
-                source_id="TopVolantis",
-                target_id="VOLANTIS GP. Top",
-            ),
-            StratigraphyIdentifierMapping(
-                source_system=DataSystem.rms,
-                target_system=DataSystem.smda,
-                relation_type=RelationType.alias,
-                source_id="TopVOLANTIS",
-                target_id="VOLANTIS GP. Top",
-            ),
-            StratigraphyIdentifierMapping(
-                source_system=DataSystem.rms,
-                target_system=DataSystem.smda,
-                relation_type=RelationType.alias,
-                source_id="TOP_VOLANTIS",
-                target_id="VOLANTIS GP. Top",
-            ),
-        ]
+def wellbore_mappings() -> FMUWellboreMappings:
+    """Returns a valid FMUWellboreMappings object."""
+    return _wellbore_mappings("30_9-B-43_A", "B43A")
+
+
+@pytest.fixture
+def stratigraphy_mappings() -> FMUStratigraphyMappings:
+    """Returns a valid FMUStratigraphyMappings object."""
+    return _stratigraphy_mappings(
+        "TopVolantis",
+        "VOLANTIS GP. Top",
+        "TopVOLANTIS",
+        "TOP_VOLANTIS",
     )
 
 
@@ -86,7 +120,7 @@ def test_mappings_manager_instantiation(
 
     expected_path = mappings_manager.fmu_dir.path / mappings_manager.relative_path
     assert mappings_manager.path == expected_path
-    assert mappings_manager.model_class == Mappings
+    assert mappings_manager.model_class == FMUMappings
     assert mappings_manager.exists is False
 
     with pytest.raises(
@@ -95,56 +129,38 @@ def test_mappings_manager_instantiation(
         mappings_manager.load()
 
 
-def test_mappings_manager_update_stratigraphy_mappings_overwrites_mappings(
+def test_mappings_manager_update_fmu_stratigraphy_mappings_overwrites_mappings(
     fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: StratigraphyMappings,
+    stratigraphy_mappings: FMUStratigraphyMappings,
 ) -> None:
     """Tests that updating stratigraphy mappings overwrites existing mappings."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
     assert mappings_manager.exists is False
 
-    mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
     assert mappings_manager.exists is True
     mappings = mappings_manager.load()
-    expected_no_of_mappings = 3
+    expected_no_of_mappings = 4
     assert len(mappings.stratigraphy) == expected_no_of_mappings
     assert mappings.stratigraphy[0] == stratigraphy_mappings[0]
 
-    new_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
-    )
+    new_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
 
-    mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[new_mapping])
-    )
+    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
 
     # Assert that existing mappings are overwritten
     mappings = mappings_manager.load()
-    assert len(mappings.stratigraphy) == 1
-    assert mappings.stratigraphy[0] == new_mapping
+    assert len(mappings.stratigraphy) == 2
+    assert mappings.stratigraphy == new_mappings
 
 
-def test_mappings_manager_update_stratigraphy_mappings_writes_to_changelog(
+def test_mappings_manager_update_fmu_stratigraphy_mappings_writes_to_changelog(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests that each update of the stratigraphy mappings, writes to the changelog."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    new_mappings = StratigraphyMappings(
-        root=[
-            StratigraphyIdentifierMapping(
-                source_system=DataSystem.rms,
-                target_system=DataSystem.smda,
-                relation_type=RelationType.primary,
-                source_id="TopViking",
-                target_id="VIKING GP. Top",
-            )
-        ]
-    )
-    mappings_manager.update_stratigraphy_mappings(new_mappings)
+    new_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
+    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
 
     changelog: Log[ChangeInfo] = mappings_manager.fmu_dir._changelog.load()
     assert len(changelog) == 1
@@ -153,54 +169,120 @@ def test_mappings_manager_update_stratigraphy_mappings_writes_to_changelog(
     assert changelog[0].key == "stratigraphy"
     assert f"New value: {new_mappings.model_dump()}" in changelog[0].change
 
-    mappings_manager.update_stratigraphy_mappings(new_mappings)
-    mappings_manager.update_stratigraphy_mappings(new_mappings)
+    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
+    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
 
     expected_no_of_mappings = 3
     assert len(mappings_manager.fmu_dir._changelog.load()) == expected_no_of_mappings
 
 
-def test_mappings_manager_update_wellbore_mappings_overwrites_mappings(
+def test_fmu_stratigraphy_mappings_converts_to_stratigraphy_mappings(
     fmu_dir: ProjectFMUDirectory,
-    wellbore_mappings: WellboreMappings,
+) -> None:
+    """Valid .fmu stratigraphy mappings are converted to fmu-datamodels mappings."""
+    mappings = FMUStratigraphyMappings(
+        root=[
+            *_stratigraphy_mappings(
+                "TopVolantis",
+                "VOLANTIS GP. Top",
+                "TopVOLANTIS",
+                "TOP_VOLANTIS",
+            ),
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.rms,
+                relation_type=FMURelationType.primary,
+                source_id="Seabase",
+                target_id="Seabase",
+                target_uuid=None,
+            ),
+            FMUStratigraphyIdentifierMapping(
+                source_system=DataSystem.rms,
+                target_system=DataSystem.smda,
+                relation_type=FMURelationType.unmappable,
+                source_id="Seabase",
+                target_id=None,
+                target_uuid=None,
+            ),
+        ]
+    )
+
+    converted = mappings.to_stratigraphy_mappings()
+
+    assert isinstance(converted, StratigraphyMappings)
+    assert converted.model_dump(mode="json", exclude_none=True) == [
+        {
+            "source_system": "rms",
+            "target_system": "smda",
+            "mapping_type": "stratigraphy",
+            "relation_type": "primary",
+            "source_id": "TopVolantis",
+            "target_id": "VOLANTIS GP. Top",
+        },
+        {
+            "source_system": "rms",
+            "target_system": "smda",
+            "mapping_type": "stratigraphy",
+            "relation_type": "alias",
+            "source_id": "TopVOLANTIS",
+            "target_id": "VOLANTIS GP. Top",
+        },
+        {
+            "source_system": "rms",
+            "target_system": "smda",
+            "mapping_type": "stratigraphy",
+            "relation_type": "alias",
+            "source_id": "TOP_VOLANTIS",
+            "target_id": "VOLANTIS GP. Top",
+        },
+    ]
+
+
+def test_mappings_manager_update_fmu_wellbore_mappings_overwrites_mappings(
+    fmu_dir: ProjectFMUDirectory,
+    wellbore_mappings: FMUWellboreMappings,
 ) -> None:
     """Tests that updating wellbore mappings overwrites existing mappings."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
     assert mappings_manager.exists is False
 
-    mappings_manager.update_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
     assert mappings_manager.exists is True
     mappings = mappings_manager.load()
-    assert len(mappings.wellbore) == 1
+    assert len(mappings.wellbore) == 2
     assert mappings.wellbore[0] == wellbore_mappings[0]
+    assert isinstance(mappings_manager.wellbore_mappings, WellboreMappings)
+    assert mappings_manager.wellbore_mappings.model_dump(
+        mode="json", exclude_none=True
+    ) == [
+        {
+            "source_system": "rms",
+            "target_system": "simulator",
+            "mapping_type": "wellbore",
+            "relation_type": "primary",
+            "source_id": "30_9-B-43_A",
+            "target_id": "B43A",
+        }
+    ]
 
-    new_mapping = WellboreIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.simulator,
-        mapping_type=MappingType.wellbore,
-        relation_type=RelationType.primary,
-        source_id="30_9-B-43_B",
-        source_uuid=None,
-        target_id="B43B",
-        target_uuid=None,
-    )
+    new_mappings = _wellbore_mappings("30_9-B-43_B", "B43B")
 
-    mappings_manager.update_wellbore_mappings(WellboreMappings(root=[new_mapping]))
+    mappings_manager.update_fmu_wellbore_mappings(new_mappings)
 
     # Assert that existing mappings are overwritten
     mappings = mappings_manager.load()
-    assert len(mappings.wellbore) == 1
-    assert mappings.wellbore[0] == new_mapping
+    assert len(mappings.wellbore) == 2
+    assert mappings.wellbore == new_mappings
 
 
-def test_mappings_manager_update_wellbore_mappings_writes_to_changelog(
+def test_mappings_manager_update_fmu_wellbore_mappings_writes_to_changelog(
     fmu_dir: ProjectFMUDirectory,
-    wellbore_mappings: WellboreMappings,
+    wellbore_mappings: FMUWellboreMappings,
 ) -> None:
     """Tests that each update of the wellbore mappings writes to the changelog."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
 
-    mappings_manager.update_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
 
     changelog: Log[ChangeInfo] = mappings_manager.fmu_dir._changelog.load()
     assert len(changelog) == 1
@@ -209,8 +291,8 @@ def test_mappings_manager_update_wellbore_mappings_writes_to_changelog(
     assert changelog[0].key == "wellbore"
     assert f"New value: {wellbore_mappings.model_dump()}" in changelog[0].change
 
-    mappings_manager.update_wellbore_mappings(wellbore_mappings)
-    mappings_manager.update_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
 
     expected_no_of_mappings = 3
     assert len(mappings_manager.fmu_dir._changelog.load()) == expected_no_of_mappings
@@ -219,34 +301,27 @@ def test_mappings_manager_update_wellbore_mappings_writes_to_changelog(
 def test_mappings_manager_diff(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: StratigraphyMappings,
+    stratigraphy_mappings: FMUStratigraphyMappings,
 ) -> None:
     """Tests that the mappings diff equals the mappings from the incoming resource."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
 
     new_mappings_manager: MappingsManager = MappingsManager(extra_fmu_dir)
-    new_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
-    )
-    new_mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[new_mapping])
+    new_mappings_manager.update_fmu_stratigraphy_mappings(
+        _stratigraphy_mappings("TopViking", "VIKING GP. Top")
     )
 
     diff = mappings_manager.get_mappings_diff(new_mappings_manager)
 
-    assert len(diff.stratigraphy) == 1
+    assert len(diff.stratigraphy) == 2
     assert diff.stratigraphy == new_mappings_manager.load().stratigraphy
 
 
 def test_mappings_manager_diff_mappings_raises(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: StratigraphyMappings,
+    stratigraphy_mappings: FMUStratigraphyMappings,
 ) -> None:
     """Exception is raised when any of the mappings resources to diff does not exist.
 
@@ -265,7 +340,7 @@ def test_mappings_manager_diff_mappings_raises(
     with pytest.raises(FileNotFoundError, match=expected_exp.format("False", "False")):
         mappings_manager.get_mappings_diff(new_mappings_manager)
 
-    mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
 
     with pytest.raises(FileNotFoundError, match=expected_exp.format("True", "False")):
         mappings_manager.get_mappings_diff(new_mappings_manager)
@@ -273,15 +348,15 @@ def test_mappings_manager_diff_mappings_raises(
     with pytest.raises(FileNotFoundError, match=expected_exp.format("False", "True")):
         new_mappings_manager.get_mappings_diff(mappings_manager)
 
-    new_mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
+    new_mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
     assert mappings_manager.get_mappings_diff(new_mappings_manager)
 
 
 def test_mappings_manager_merge_mappings(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: StratigraphyMappings,
-    wellbore_mappings: WellboreMappings,
+    stratigraphy_mappings: FMUStratigraphyMappings,
+    wellbore_mappings: FMUWellboreMappings,
 ) -> None:
     """Tests that mappings from the incoming resource will overwrite current mappings.
 
@@ -289,54 +364,52 @@ def test_mappings_manager_merge_mappings(
     from the incoming resource.
     """
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
-    assert mappings_manager.stratigraphy_mappings == stratigraphy_mappings
+    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    assert mappings_manager.fmu_stratigraphy_mappings == stratigraphy_mappings
 
     new_mappings_manager: MappingsManager = MappingsManager(extra_fmu_dir)
-    new_mappings_manager.update_stratigraphy_mappings(StratigraphyMappings(root=[]))
+    new_mappings_manager.update_fmu_stratigraphy_mappings(
+        FMUStratigraphyMappings(root=[])
+    )
 
     updated_mappings = mappings_manager.merge_mappings(new_mappings_manager)
 
     assert len(updated_mappings.stratigraphy) == 0
-    assert updated_mappings.stratigraphy == mappings_manager.stratigraphy_mappings
+    assert updated_mappings.stratigraphy == mappings_manager.fmu_stratigraphy_mappings
     assert len(updated_mappings.wellbore) == 0
 
-    mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
-    expected_no_of_mappings = 3
-    assert len(mappings_manager.stratigraphy_mappings) == expected_no_of_mappings
+    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    expected_no_of_mappings = 4
+    assert len(mappings_manager.fmu_stratigraphy_mappings) == expected_no_of_mappings
 
-    new_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
+    new_mappings_manager.update_fmu_stratigraphy_mappings(
+        _stratigraphy_mappings("TopViking", "VIKING GP. Top")
     )
-    new_mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(root=[new_mapping])
-    )
-    assert len(new_mappings_manager.stratigraphy_mappings) == 1
+    assert len(new_mappings_manager.fmu_stratigraphy_mappings) == 2
 
     updated_mappings = mappings_manager.merge_mappings(new_mappings_manager)
 
-    assert len(updated_mappings.stratigraphy) == 1
-    assert updated_mappings.stratigraphy == mappings_manager.stratigraphy_mappings
+    assert len(updated_mappings.stratigraphy) == 2
+    assert updated_mappings.stratigraphy == mappings_manager.fmu_stratigraphy_mappings
     assert (
-        mappings_manager.stratigraphy_mappings
-        == new_mappings_manager.stratigraphy_mappings
+        mappings_manager.fmu_stratigraphy_mappings
+        == new_mappings_manager.fmu_stratigraphy_mappings
     )
 
-    new_mappings_manager.update_wellbore_mappings(wellbore_mappings)
+    new_mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
     updated_mappings = mappings_manager.merge_mappings(new_mappings_manager)
-    assert updated_mappings.wellbore == mappings_manager.wellbore_mappings
-    assert mappings_manager.wellbore_mappings == new_mappings_manager.wellbore_mappings
-    assert len(updated_mappings.wellbore) == 1
+    assert updated_mappings.wellbore == mappings_manager.fmu_wellbore_mappings
+    assert (
+        mappings_manager.fmu_wellbore_mappings
+        == new_mappings_manager.fmu_wellbore_mappings
+    )
+    assert len(updated_mappings.wellbore) == 2
 
 
 def test_mappings_manager_merge_changes(
     fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: StratigraphyMappings,
-    wellbore_mappings: WellboreMappings,
+    stratigraphy_mappings: FMUStratigraphyMappings,
+    wellbore_mappings: FMUWellboreMappings,
 ) -> None:
     """Tests that mappings from the change object will overwrite current mappings.
 
@@ -344,66 +417,51 @@ def test_mappings_manager_merge_changes(
     from the change object.
     """
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(stratigraphy_mappings)
-    assert mappings_manager.stratigraphy_mappings == stratigraphy_mappings
+    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    assert mappings_manager.fmu_stratigraphy_mappings == stratigraphy_mappings
 
     # Assert empty change object overwrites current mappings
-    change_object = Mappings()
+    change_object = FMUMappings()
     updated_mappings = mappings_manager.merge_changes(change_object)
-    assert updated_mappings.stratigraphy == mappings_manager.stratigraphy_mappings
-    assert len(mappings_manager.stratigraphy_mappings) == 0
-    assert len(mappings_manager.wellbore_mappings) == 0
+    assert updated_mappings.stratigraphy == mappings_manager.fmu_stratigraphy_mappings
+    assert len(mappings_manager.fmu_stratigraphy_mappings) == 0
+    assert len(mappings_manager.fmu_wellbore_mappings) == 0
 
-    new_mappings = StratigraphyMappings(
-        root=[
-            StratigraphyIdentifierMapping(
-                source_system=DataSystem.rms,
-                target_system=DataSystem.smda,
-                relation_type=RelationType.primary,
-                source_id="TopViking",
-                target_id="VIKING GP. Top",
-            )
-        ]
-    )
+    new_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
 
     # Assert change object overwrites current mappings
     change_object.stratigraphy = new_mappings
     updated_mappings = mappings_manager.merge_changes(change_object)
 
     assert len(updated_mappings.wellbore) == 0
-    assert len(updated_mappings.stratigraphy) == 1
+    assert len(updated_mappings.stratigraphy) == 2
     assert updated_mappings.stratigraphy == new_mappings
-    assert mappings_manager.stratigraphy_mappings == new_mappings
+    assert mappings_manager.fmu_stratigraphy_mappings == new_mappings
 
     change_object.wellbore = wellbore_mappings
     updated_mappings = mappings_manager.merge_changes(change_object)
     assert updated_mappings.wellbore == wellbore_mappings
-    assert mappings_manager.wellbore_mappings == wellbore_mappings
-    assert len(updated_mappings.wellbore) == 1
+    assert mappings_manager.fmu_wellbore_mappings == wellbore_mappings
+    assert len(updated_mappings.wellbore) == 2
 
 
 def test_mappings_manager_structured_diff_uses_full_item_identity(
     fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: StratigraphyMappings,
+    stratigraphy_mappings: FMUStratigraphyMappings,
 ) -> None:
     """Tests stratigraphy list changes are returned as added/removed with __full__."""
     mappings_manager = MappingsManager(fmu_dir)
 
-    replacement_mapping = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopViking",
-        target_id="VIKING GP. Top",
-    )
+    replacement_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
 
-    current_model = Mappings(stratigraphy=stratigraphy_mappings)
-    incoming_model = Mappings(
-        stratigraphy=StratigraphyMappings(
+    current_model = FMUMappings(stratigraphy=stratigraphy_mappings)
+    incoming_model = FMUMappings(
+        stratigraphy=FMUStratigraphyMappings(
             root=[
                 stratigraphy_mappings[0],
                 stratigraphy_mappings[2],
-                replacement_mapping,
+                stratigraphy_mappings[3],
+                *replacement_mappings,
             ]
         )
     )
@@ -416,10 +474,10 @@ def test_mappings_manager_structured_diff_uses_full_item_identity(
     diff = model_diff[0]
     assert isinstance(diff, ListFieldDiff)
     assert diff.field_path == "stratigraphy.root"
-    assert len(diff.added) == 1
+    assert len(diff.added) == 2
     assert len(diff.removed) == 1
     assert diff.updated == []
-    assert diff.added[0]["source_id"] == "TopViking"
+    assert {mapping["source_id"] for mapping in diff.added} == {"TopViking"}
     assert diff.removed[0]["source_id"] == "TopVOLANTIS"
 
 
@@ -489,18 +547,8 @@ def test_build_global_config_stratigraphy_only_mappings(
 ) -> None:
     """Only stratigraphic entries when there is no RMS config."""
     mappings_manager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(
-            root=[
-                StratigraphyIdentifierMapping(
-                    source_system=DataSystem.rms,
-                    target_system=DataSystem.smda,
-                    relation_type=RelationType.primary,
-                    source_id="TopX",
-                    target_id="X Fm. Top",
-                ),
-            ]
-        )
+    mappings_manager.update_fmu_stratigraphy_mappings(
+        _stratigraphy_mappings("TopX", "X Fm. Top")
     )
 
     strat = mappings_manager.build_global_config_stratigraphy()
@@ -527,18 +575,8 @@ def test_build_global_config_stratigraphy_mapped_horizon_not_duplicated(
         }
     )
     mappings_manager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(
-            root=[
-                StratigraphyIdentifierMapping(
-                    source_system=DataSystem.rms,
-                    target_system=DataSystem.smda,
-                    relation_type=RelationType.primary,
-                    source_id="TopX",
-                    target_id="X Fm. Top",
-                ),
-            ]
-        )
+    mappings_manager.update_fmu_stratigraphy_mappings(
+        _stratigraphy_mappings("TopX", "X Fm. Top")
     )
 
     strat = mappings_manager.build_global_config_stratigraphy()

--- a/tests/test_resources/test_mappings_manager.py
+++ b/tests/test_resources/test_mappings_manager.py
@@ -17,12 +17,12 @@ from fmu.settings._resources.mappings_manager import MappingsManager
 from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.diff import ListFieldDiff
 from fmu.settings.models.mappings import (
-    FMUMappings,
-    FMURelationType,
-    FMUStratigraphyIdentifierMapping,
-    FMUStratigraphyMappings,
-    FMUWellboreIdentifierMapping,
-    FMUWellboreMappings,
+    InternalMappings,
+    InternalRelationType,
+    InternalStratigraphyIdentifierMapping,
+    InternalStratigraphyMappings,
+    InternalWellboreIdentifierMapping,
+    InternalWellboreMappings,
 )
 
 if TYPE_CHECKING:
@@ -34,30 +34,30 @@ def _stratigraphy_mappings(
     source_id: str,
     target_id: str,
     *aliases: str,
-) -> FMUStratigraphyMappings:
-    return FMUStratigraphyMappings(
+) -> InternalStratigraphyMappings:
+    return InternalStratigraphyMappings(
         root=[
-            FMUStratigraphyIdentifierMapping(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.rms,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 target_id=source_id,
             ),
             *[
-                FMUStratigraphyIdentifierMapping(
+                InternalStratigraphyIdentifierMapping(
                     source_system=DataSystem.rms,
                     target_system=DataSystem.rms,
-                    relation_type=FMURelationType.alias,
+                    relation_type=InternalRelationType.alias,
                     source_id=alias,
                     target_id=source_id,
                 )
                 for alias in aliases
             ],
-            FMUStratigraphyIdentifierMapping(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.smda,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 target_id=target_id,
             ),
@@ -65,24 +65,24 @@ def _stratigraphy_mappings(
     )
 
 
-def _wellbore_mappings(source_id: str, target_id: str) -> FMUWellboreMappings:
-    return FMUWellboreMappings(
+def _wellbore_mappings(source_id: str, target_id: str) -> InternalWellboreMappings:
+    return InternalWellboreMappings(
         root=[
-            FMUWellboreIdentifierMapping(
+            InternalWellboreIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.rms,
                 mapping_type=MappingType.wellbore,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 source_uuid=None,
                 target_id=source_id,
                 target_uuid=None,
             ),
-            FMUWellboreIdentifierMapping(
+            InternalWellboreIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.simulator,
                 mapping_type=MappingType.wellbore,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 source_uuid=None,
                 target_id=target_id,
@@ -93,14 +93,14 @@ def _wellbore_mappings(source_id: str, target_id: str) -> FMUWellboreMappings:
 
 
 @pytest.fixture
-def wellbore_mappings() -> FMUWellboreMappings:
-    """Returns a valid FMUWellboreMappings object."""
+def wellbore_mappings() -> InternalWellboreMappings:
+    """Returns a valid InternalWellboreMappings object."""
     return _wellbore_mappings("30_9-B-43_A", "B43A")
 
 
 @pytest.fixture
-def stratigraphy_mappings() -> FMUStratigraphyMappings:
-    """Returns a valid FMUStratigraphyMappings object."""
+def stratigraphy_mappings() -> InternalStratigraphyMappings:
+    """Returns a valid InternalStratigraphyMappings object."""
     return _stratigraphy_mappings(
         "TopVolantis",
         "VOLANTIS GP. Top",
@@ -120,7 +120,7 @@ def test_mappings_manager_instantiation(
 
     expected_path = mappings_manager.fmu_dir.path / mappings_manager.relative_path
     assert mappings_manager.path == expected_path
-    assert mappings_manager.model_class == FMUMappings
+    assert mappings_manager.model_class == InternalMappings
     assert mappings_manager.exists is False
 
     with pytest.raises(
@@ -129,15 +129,15 @@ def test_mappings_manager_instantiation(
         mappings_manager.load()
 
 
-def test_mappings_manager_update_fmu_stratigraphy_mappings_overwrites_mappings(
+def test_mappings_manager_update_internal_stratigraphy_mappings_overwrites_mappings(
     fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: FMUStratigraphyMappings,
+    stratigraphy_mappings: InternalStratigraphyMappings,
 ) -> None:
     """Tests that updating stratigraphy mappings overwrites existing mappings."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
     assert mappings_manager.exists is False
 
-    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
     assert mappings_manager.exists is True
     mappings = mappings_manager.load()
     expected_no_of_mappings = 4
@@ -146,7 +146,7 @@ def test_mappings_manager_update_fmu_stratigraphy_mappings_overwrites_mappings(
 
     new_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
 
-    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(new_mappings)
 
     # Assert that existing mappings are overwritten
     mappings = mappings_manager.load()
@@ -154,13 +154,13 @@ def test_mappings_manager_update_fmu_stratigraphy_mappings_overwrites_mappings(
     assert mappings.stratigraphy == new_mappings
 
 
-def test_mappings_manager_update_fmu_stratigraphy_mappings_writes_to_changelog(
+def test_mappings_manager_update_internal_stratigraphy_mappings_writes_to_changelog(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Tests that each update of the stratigraphy mappings, writes to the changelog."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
     new_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
-    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(new_mappings)
 
     changelog: Log[ChangeInfo] = mappings_manager.fmu_dir._changelog.load()
     assert len(changelog) == 1
@@ -169,18 +169,18 @@ def test_mappings_manager_update_fmu_stratigraphy_mappings_writes_to_changelog(
     assert changelog[0].key == "stratigraphy"
     assert f"New value: {new_mappings.model_dump()}" in changelog[0].change
 
-    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
-    mappings_manager.update_fmu_stratigraphy_mappings(new_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(new_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(new_mappings)
 
     expected_no_of_mappings = 3
     assert len(mappings_manager.fmu_dir._changelog.load()) == expected_no_of_mappings
 
 
-def test_fmu_stratigraphy_mappings_converts_to_stratigraphy_mappings(
+def test_internal_stratigraphy_mappings_converts_to_stratigraphy_mappings(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:
     """Valid .fmu stratigraphy mappings are converted to fmu-datamodels mappings."""
-    mappings = FMUStratigraphyMappings(
+    mappings = InternalStratigraphyMappings(
         root=[
             *_stratigraphy_mappings(
                 "TopVolantis",
@@ -188,18 +188,18 @@ def test_fmu_stratigraphy_mappings_converts_to_stratigraphy_mappings(
                 "TopVOLANTIS",
                 "TOP_VOLANTIS",
             ),
-            FMUStratigraphyIdentifierMapping(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.rms,
-                relation_type=FMURelationType.primary,
+                relation_type=InternalRelationType.primary,
                 source_id="Seabase",
                 target_id="Seabase",
                 target_uuid=None,
             ),
-            FMUStratigraphyIdentifierMapping(
+            InternalStratigraphyIdentifierMapping(
                 source_system=DataSystem.rms,
                 target_system=DataSystem.smda,
-                relation_type=FMURelationType.unmappable,
+                relation_type=InternalRelationType.unmappable,
                 source_id="Seabase",
                 target_id=None,
                 target_uuid=None,
@@ -238,15 +238,15 @@ def test_fmu_stratigraphy_mappings_converts_to_stratigraphy_mappings(
     ]
 
 
-def test_mappings_manager_update_fmu_wellbore_mappings_overwrites_mappings(
+def test_mappings_manager_update_internal_wellbore_mappings_overwrites_mappings(
     fmu_dir: ProjectFMUDirectory,
-    wellbore_mappings: FMUWellboreMappings,
+    wellbore_mappings: InternalWellboreMappings,
 ) -> None:
     """Tests that updating wellbore mappings overwrites existing mappings."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
     assert mappings_manager.exists is False
 
-    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_internal_wellbore_mappings(wellbore_mappings)
     assert mappings_manager.exists is True
     mappings = mappings_manager.load()
     assert len(mappings.wellbore) == 2
@@ -267,7 +267,7 @@ def test_mappings_manager_update_fmu_wellbore_mappings_overwrites_mappings(
 
     new_mappings = _wellbore_mappings("30_9-B-43_B", "B43B")
 
-    mappings_manager.update_fmu_wellbore_mappings(new_mappings)
+    mappings_manager.update_internal_wellbore_mappings(new_mappings)
 
     # Assert that existing mappings are overwritten
     mappings = mappings_manager.load()
@@ -275,14 +275,14 @@ def test_mappings_manager_update_fmu_wellbore_mappings_overwrites_mappings(
     assert mappings.wellbore == new_mappings
 
 
-def test_mappings_manager_update_fmu_wellbore_mappings_writes_to_changelog(
+def test_mappings_manager_update_internal_wellbore_mappings_writes_to_changelog(
     fmu_dir: ProjectFMUDirectory,
-    wellbore_mappings: FMUWellboreMappings,
+    wellbore_mappings: InternalWellboreMappings,
 ) -> None:
     """Tests that each update of the wellbore mappings writes to the changelog."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
 
-    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_internal_wellbore_mappings(wellbore_mappings)
 
     changelog: Log[ChangeInfo] = mappings_manager.fmu_dir._changelog.load()
     assert len(changelog) == 1
@@ -291,8 +291,8 @@ def test_mappings_manager_update_fmu_wellbore_mappings_writes_to_changelog(
     assert changelog[0].key == "wellbore"
     assert f"New value: {wellbore_mappings.model_dump()}" in changelog[0].change
 
-    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
-    mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_internal_wellbore_mappings(wellbore_mappings)
+    mappings_manager.update_internal_wellbore_mappings(wellbore_mappings)
 
     expected_no_of_mappings = 3
     assert len(mappings_manager.fmu_dir._changelog.load()) == expected_no_of_mappings
@@ -301,14 +301,14 @@ def test_mappings_manager_update_fmu_wellbore_mappings_writes_to_changelog(
 def test_mappings_manager_diff(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: FMUStratigraphyMappings,
+    stratigraphy_mappings: InternalStratigraphyMappings,
 ) -> None:
     """Tests that the mappings diff equals the mappings from the incoming resource."""
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
 
     new_mappings_manager: MappingsManager = MappingsManager(extra_fmu_dir)
-    new_mappings_manager.update_fmu_stratigraphy_mappings(
+    new_mappings_manager.update_internal_stratigraphy_mappings(
         _stratigraphy_mappings("TopViking", "VIKING GP. Top")
     )
 
@@ -321,7 +321,7 @@ def test_mappings_manager_diff(
 def test_mappings_manager_diff_mappings_raises(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: FMUStratigraphyMappings,
+    stratigraphy_mappings: InternalStratigraphyMappings,
 ) -> None:
     """Exception is raised when any of the mappings resources to diff does not exist.
 
@@ -340,7 +340,7 @@ def test_mappings_manager_diff_mappings_raises(
     with pytest.raises(FileNotFoundError, match=expected_exp.format("False", "False")):
         mappings_manager.get_mappings_diff(new_mappings_manager)
 
-    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
 
     with pytest.raises(FileNotFoundError, match=expected_exp.format("True", "False")):
         mappings_manager.get_mappings_diff(new_mappings_manager)
@@ -348,15 +348,15 @@ def test_mappings_manager_diff_mappings_raises(
     with pytest.raises(FileNotFoundError, match=expected_exp.format("False", "True")):
         new_mappings_manager.get_mappings_diff(mappings_manager)
 
-    new_mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    new_mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
     assert mappings_manager.get_mappings_diff(new_mappings_manager)
 
 
 def test_mappings_manager_merge_mappings(
     fmu_dir: ProjectFMUDirectory,
     extra_fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: FMUStratigraphyMappings,
-    wellbore_mappings: FMUWellboreMappings,
+    stratigraphy_mappings: InternalStratigraphyMappings,
+    wellbore_mappings: InternalWellboreMappings,
 ) -> None:
     """Tests that mappings from the incoming resource will overwrite current mappings.
 
@@ -364,52 +364,58 @@ def test_mappings_manager_merge_mappings(
     from the incoming resource.
     """
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
-    assert mappings_manager.fmu_stratigraphy_mappings == stratigraphy_mappings
+    mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
+    assert mappings_manager.internal_stratigraphy_mappings == stratigraphy_mappings
 
     new_mappings_manager: MappingsManager = MappingsManager(extra_fmu_dir)
-    new_mappings_manager.update_fmu_stratigraphy_mappings(
-        FMUStratigraphyMappings(root=[])
+    new_mappings_manager.update_internal_stratigraphy_mappings(
+        InternalStratigraphyMappings(root=[])
     )
 
     updated_mappings = mappings_manager.merge_mappings(new_mappings_manager)
 
     assert len(updated_mappings.stratigraphy) == 0
-    assert updated_mappings.stratigraphy == mappings_manager.fmu_stratigraphy_mappings
+    assert (
+        updated_mappings.stratigraphy == mappings_manager.internal_stratigraphy_mappings
+    )
     assert len(updated_mappings.wellbore) == 0
 
-    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
+    mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
     expected_no_of_mappings = 4
-    assert len(mappings_manager.fmu_stratigraphy_mappings) == expected_no_of_mappings
+    assert (
+        len(mappings_manager.internal_stratigraphy_mappings) == expected_no_of_mappings
+    )
 
-    new_mappings_manager.update_fmu_stratigraphy_mappings(
+    new_mappings_manager.update_internal_stratigraphy_mappings(
         _stratigraphy_mappings("TopViking", "VIKING GP. Top")
     )
-    assert len(new_mappings_manager.fmu_stratigraphy_mappings) == 2
+    assert len(new_mappings_manager.internal_stratigraphy_mappings) == 2
 
     updated_mappings = mappings_manager.merge_mappings(new_mappings_manager)
 
     assert len(updated_mappings.stratigraphy) == 2
-    assert updated_mappings.stratigraphy == mappings_manager.fmu_stratigraphy_mappings
     assert (
-        mappings_manager.fmu_stratigraphy_mappings
-        == new_mappings_manager.fmu_stratigraphy_mappings
+        updated_mappings.stratigraphy == mappings_manager.internal_stratigraphy_mappings
+    )
+    assert (
+        mappings_manager.internal_stratigraphy_mappings
+        == new_mappings_manager.internal_stratigraphy_mappings
     )
 
-    new_mappings_manager.update_fmu_wellbore_mappings(wellbore_mappings)
+    new_mappings_manager.update_internal_wellbore_mappings(wellbore_mappings)
     updated_mappings = mappings_manager.merge_mappings(new_mappings_manager)
-    assert updated_mappings.wellbore == mappings_manager.fmu_wellbore_mappings
+    assert updated_mappings.wellbore == mappings_manager.internal_wellbore_mappings
     assert (
-        mappings_manager.fmu_wellbore_mappings
-        == new_mappings_manager.fmu_wellbore_mappings
+        mappings_manager.internal_wellbore_mappings
+        == new_mappings_manager.internal_wellbore_mappings
     )
     assert len(updated_mappings.wellbore) == 2
 
 
 def test_mappings_manager_merge_changes(
     fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: FMUStratigraphyMappings,
-    wellbore_mappings: FMUWellboreMappings,
+    stratigraphy_mappings: InternalStratigraphyMappings,
+    wellbore_mappings: InternalWellboreMappings,
 ) -> None:
     """Tests that mappings from the change object will overwrite current mappings.
 
@@ -417,15 +423,17 @@ def test_mappings_manager_merge_changes(
     from the change object.
     """
     mappings_manager: MappingsManager = MappingsManager(fmu_dir)
-    mappings_manager.update_fmu_stratigraphy_mappings(stratigraphy_mappings)
-    assert mappings_manager.fmu_stratigraphy_mappings == stratigraphy_mappings
+    mappings_manager.update_internal_stratigraphy_mappings(stratigraphy_mappings)
+    assert mappings_manager.internal_stratigraphy_mappings == stratigraphy_mappings
 
     # Assert empty change object overwrites current mappings
-    change_object = FMUMappings()
+    change_object = InternalMappings()
     updated_mappings = mappings_manager.merge_changes(change_object)
-    assert updated_mappings.stratigraphy == mappings_manager.fmu_stratigraphy_mappings
-    assert len(mappings_manager.fmu_stratigraphy_mappings) == 0
-    assert len(mappings_manager.fmu_wellbore_mappings) == 0
+    assert (
+        updated_mappings.stratigraphy == mappings_manager.internal_stratigraphy_mappings
+    )
+    assert len(mappings_manager.internal_stratigraphy_mappings) == 0
+    assert len(mappings_manager.internal_wellbore_mappings) == 0
 
     new_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
 
@@ -436,27 +444,27 @@ def test_mappings_manager_merge_changes(
     assert len(updated_mappings.wellbore) == 0
     assert len(updated_mappings.stratigraphy) == 2
     assert updated_mappings.stratigraphy == new_mappings
-    assert mappings_manager.fmu_stratigraphy_mappings == new_mappings
+    assert mappings_manager.internal_stratigraphy_mappings == new_mappings
 
     change_object.wellbore = wellbore_mappings
     updated_mappings = mappings_manager.merge_changes(change_object)
     assert updated_mappings.wellbore == wellbore_mappings
-    assert mappings_manager.fmu_wellbore_mappings == wellbore_mappings
+    assert mappings_manager.internal_wellbore_mappings == wellbore_mappings
     assert len(updated_mappings.wellbore) == 2
 
 
 def test_mappings_manager_structured_diff_uses_full_item_identity(
     fmu_dir: ProjectFMUDirectory,
-    stratigraphy_mappings: FMUStratigraphyMappings,
+    stratigraphy_mappings: InternalStratigraphyMappings,
 ) -> None:
     """Tests stratigraphy list changes are returned as added/removed with __full__."""
     mappings_manager = MappingsManager(fmu_dir)
 
     replacement_mappings = _stratigraphy_mappings("TopViking", "VIKING GP. Top")
 
-    current_model = FMUMappings(stratigraphy=stratigraphy_mappings)
-    incoming_model = FMUMappings(
-        stratigraphy=FMUStratigraphyMappings(
+    current_model = InternalMappings(stratigraphy=stratigraphy_mappings)
+    incoming_model = InternalMappings(
+        stratigraphy=InternalStratigraphyMappings(
             root=[
                 stratigraphy_mappings[0],
                 stratigraphy_mappings[2],
@@ -547,7 +555,7 @@ def test_build_global_config_stratigraphy_only_mappings(
 ) -> None:
     """Only stratigraphic entries when there is no RMS config."""
     mappings_manager = MappingsManager(fmu_dir)
-    mappings_manager.update_fmu_stratigraphy_mappings(
+    mappings_manager.update_internal_stratigraphy_mappings(
         _stratigraphy_mappings("TopX", "X Fm. Top")
     )
 
@@ -575,7 +583,7 @@ def test_build_global_config_stratigraphy_mapped_horizon_not_duplicated(
         }
     )
     mappings_manager = MappingsManager(fmu_dir)
-    mappings_manager.update_fmu_stratigraphy_mappings(
+    mappings_manager.update_internal_stratigraphy_mappings(
         _stratigraphy_mappings("TopX", "X Fm. Top")
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -84,11 +84,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -325,14 +325,14 @@ wheels = [
 
 [[package]]
 name = "fmu-datamodels"
-version = "0.21.0"
+version = "0.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/b1/836bdff08ad83fdf19a3d4e56c022e5da248935174a8b2e1821a6b979bad/fmu_datamodels-0.21.0.tar.gz", hash = "sha256:e7e686b64546e680efb05f006f74c5566183d1bcddf5dc1d717533d69fe8dd3c", size = 404396, upload-time = "2026-04-17T10:37:42.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/89/f1f4eeb336b9e39f2106f8ba63271bf38e6fd4d9d34a457eeba93d89aa51/fmu_datamodels-0.21.3.tar.gz", hash = "sha256:a36f030670f781c43d53d08605edcd7d0a61beded74c2aa2911dc9314f407254", size = 404179, upload-time = "2026-05-04T10:59:43.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/e1/58e2435b41c4c67c806184af23f80a09716cec2cad5e0c94630ef144ef73/fmu_datamodels-0.21.0-py3-none-any.whl", hash = "sha256:65c855dfd076548131b3a099e9e979dab3962ea25c1ac432cfe5b6883b7ffb61", size = 52938, upload-time = "2026-04-17T10:37:40.785Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/cd/bf7bad4d07bd1f450ba7c9a81f80eca54bdaba6637c09b6cafc128766f1b/fmu_datamodels-0.21.3-py3-none-any.whl", hash = "sha256:06d7115a276684f403394f77672e9da4cf75c3e66f0be83524bf5ea9443375b3", size = 52222, upload-time = "2026-05-04T10:59:41.874Z" },
 ]
 
 [[package]]
@@ -413,11 +413,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -788,11 +788,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -869,11 +869,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1004,16 +1004,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]
@@ -1510,11 +1510,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.1"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #234
Resolves #237

- Removed `MappingGroup` as it's not relevant
- Introduced an internal `.fmu` mappings model: `InternalRelationType` with `unmappable`, `InternalBaseMapping`, `InternalIdentifierMapping`, `InternalStratigraphyMappings`, `InternalWellboreMappings`, and `InternalMappings`. These model have the stricter validation rules for our internal use
- `InternalMappings` is the new internal mappings model that replace `Mappings`
- Added conversion from internal `.fmu` mappings model to mappings in `fmu-datamodels` via `InternalStratigraphyMappings.to_stratigraphy_mappings()` and `InternalWellboreMappings.to_wellbore_mappings()`
- Updated `MappingsManager`:
  `load()` now manages `InternalMappings`
  internal properties are `internal_stratigraphy_mappings` / `internal_wellbore_mappings`
  regular properties `stratigraphy_mappings` / `wellbore_mappings` return `fmu-datamodels` mappings
  update methods renamed to `update_internal_stratigraphy_mappings()` / `update_internal_wellbore_mappings()`
  `build_global_config_stratigraphy()` now uses the converted stratigraphy model, not internal .fmu mappings model
- Updated Drogon setup and tests to write internal mappings but compare the converted mapping model

So mappings manager's `load()` behavior by default is using the `.fmu` internal mapping model, as it's the resource manager of mappings file in `.fmu`. However, to access it, the caller has to explicitly call it like this: `self._fmu_dir.mappings.internal_stratigraphy_mappings`. If the caller does `self._fmu_dir.mappings.stratigraphy_mappings`, it will return the `StratigraphyMappings` from `fmu-datamodels`. This converted mappings can then be exported easily by `fmu-dataio` to Sumo if it's desired. I think this is clear enough.

Ready to review @slangeveld @tnatt 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅