### PR TITLE
MAINT: Remove equivalent relation_type

### DIFF
--- a/src/fmu/settings/_drogon/_data.py
+++ b/src/fmu/settings/_drogon/_data.py
@@ -183,14 +183,6 @@ STRATIGRAPHY_MAPPINGS: Final[list[dict[str, Any]]] = [
         "target_id": "Therys Fm. Top",
         "target_uuid": "0240dc8e-659a-4925-b569-6f1570ba6770",
     },
-    {  # Equivalent
-        "source_system": "rms",
-        "target_system": "smda",
-        "relation_type": "equivalent",
-        "source_id": "Therys Fm. Top",
-        "target_id": "Therys Fm. Top",
-        "target_uuid": "0240dc8e-659a-4925-b569-6f1570ba6770",
-    },
     {
         "source_system": "rms",
         "target_system": "smda",

--- a/src/fmu/settings/_resources/mappings_manager.py
+++ b/src/fmu/settings/_resources/mappings_manager.py
@@ -129,7 +129,6 @@ class MappingsManager(PydanticResourceManager[Mappings]):
 
         primaries: dict[str, str] = {}  # source_id -> target_id
         aliases_by_target: dict[str, list[str]] = {}  # target_id -> [alias source_ids]
-        equivalents_by_target: dict[str, list[str]] = {}
 
         # Stratigraphic entries from stratigraphy mappings
         for mapping in mappings.stratigraphy:
@@ -139,12 +138,7 @@ class MappingsManager(PydanticResourceManager[Mappings]):
                 aliases_by_target.setdefault(mapping.target_id, []).append(
                     mapping.source_id
                 )
-            elif mapping.relation_type == RelationType.equivalent:
-                equivalents_by_target.setdefault(mapping.target_id, []).append(
-                    mapping.source_id
-                )
 
-        primary_targets = set(primaries.values())
         for source_id, target_id in primaries.items():
             entry: dict[str, Any] = {
                 "stratigraphic": True,
@@ -153,16 +147,6 @@ class MappingsManager(PydanticResourceManager[Mappings]):
             if aliases := aliases_by_target.get(target_id):
                 entry["alias"] = aliases
             stratigraphy[source_id] = entry
-
-        # Keep equivalent-only mappings as valid stratigraphic entries even when
-        # there is no separate primary RMS identifier for the same official name
-        for target_id in equivalents_by_target:
-            if target_id in primary_targets:
-                continue
-            stratigraphy[target_id] = {
-                "stratigraphic": True,
-                "name": target_id,
-            }
 
         # Non-stratigraphic entries from RMS
         rms_config = self.fmu_dir.get_config_value("rms")

--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -57,7 +57,6 @@ class MappingGroup(BaseModel):
 
         Validates that:
         - At most one primary mapping per mapping group
-        - At most one equivalent mapping per mapping group
         - Mapping group with alias mapping(s) requires a primary mapping
         - No duplicate mappings in a mappping group
         - All mappings in a mapping group share the same target_id, mapping_type,
@@ -80,12 +79,6 @@ class MappingGroup(BaseModel):
             raise ValueError(
                 f"MappingGroup for target '{self.target_id}' must contain at most one "
                 "primary mapping."
-            )
-
-        if self._count_mappings_by_relation_type(RelationType.equivalent) > 1:
-            raise ValueError(
-                f"MappingGroup for target '{self.target_id}' must contain at most one "
-                "equivalent mapping."
             )
 
         if has_alias_mapping and primary_mappings_count == 0:

--- a/tests/test_mappings_model.py
+++ b/tests/test_mappings_model.py
@@ -39,18 +39,16 @@ def test_mapping_group_count_mappings_by_relation_type() -> None:
     alias = _make_mapping("Viking gp", target_id, RelationType.alias)
     alias_two = _make_mapping("VIKING GP", target_id, RelationType.alias)
     alias_three = _make_mapping("viking.gp", target_id, RelationType.alias)
-    equivalent = _make_mapping("Viking GP.", target_id, RelationType.equivalent)
 
     mapping_group = MappingGroup(
         target_id=target_id,
         mapping_type=MappingType.stratigraphy,
         target_system=DataSystem.smda,
         source_system=DataSystem.rms,
-        mappings=[primary, alias, alias_two, alias_three, equivalent],
+        mappings=[primary, alias, alias_two, alias_three],
     )
 
     assert mapping_group._count_mappings_by_relation_type(RelationType.primary) == 1
-    assert mapping_group._count_mappings_by_relation_type(RelationType.equivalent) == 1
     expected_alias_mappings = 3
     assert (
         mapping_group._count_mappings_by_relation_type(RelationType.alias)
@@ -68,9 +66,6 @@ def test_mapping_group_serializes_without_system_and_target_fields() -> None:
     alias = _make_mapping(
         "Viking Group", target_id, RelationType.alias, target_uuid=target_uuid
     )
-    equivalent = _make_mapping(
-        target_id, target_id, RelationType.equivalent, target_uuid=target_uuid
-    )
 
     group = MappingGroup(
         target_id=target_id,
@@ -78,7 +73,7 @@ def test_mapping_group_serializes_without_system_and_target_fields() -> None:
         mapping_type=MappingType.stratigraphy,
         target_system=DataSystem.smda,
         source_system=DataSystem.rms,
-        mappings=[primary, alias, equivalent],
+        mappings=[primary, alias],
     )
 
     display_dict = group.model_dump()
@@ -112,21 +107,6 @@ def test_mapping_group_rejects_multiple_primary_mappings() -> None:
         )
 
 
-def test_mapping_group_rejects_multiple_equivalent_mappings() -> None:
-    """MappingGroup with more than one equivalent mapping raises ValidationError."""
-    target_id = "Viking GP."
-    equivalent = _make_mapping("Viking GP.", target_id, RelationType.equivalent)
-    equivalent_two = _make_mapping("Viking GP.", target_id, RelationType.equivalent)
-    with pytest.raises(ValidationError, match="at most one equivalent mapping."):
-        MappingGroup(
-            target_id=target_id,
-            mapping_type=MappingType.stratigraphy,
-            target_system=DataSystem.smda,
-            source_system=DataSystem.rms,
-            mappings=[equivalent, equivalent_two],
-        )
-
-
 def test_mapping_group_with_alias_requires_primary_relation() -> None:
     """MappingsGroup with alias mappings and no primary mapping raises ValidationError.
 
@@ -136,7 +116,6 @@ def test_mapping_group_with_alias_requires_primary_relation() -> None:
     target_id = "Viking GP."
     alias = _make_mapping("Viking gp", target_id, RelationType.alias)
     alias_two = _make_mapping("VIKING GP", target_id, RelationType.alias)
-    equivalent = _make_mapping("Viking GP.", target_id, RelationType.equivalent)
     with pytest.raises(
         ValidationError, match="contains alias relations but no primary relation."
     ):
@@ -145,7 +124,7 @@ def test_mapping_group_with_alias_requires_primary_relation() -> None:
             mapping_type=MappingType.stratigraphy,
             target_system=DataSystem.smda,
             source_system=DataSystem.rms,
-            mappings=[alias, alias_two, equivalent],
+            mappings=[alias, alias_two],
         )
 
 
@@ -187,7 +166,7 @@ def test_mapping_group_requires_shared_target_system() -> None:
         "Viking Gp 2",
         "Viking GP.",
         RelationType.alias,
-        target_system=DataSystem.fmu,
+        target_system=DataSystem.simulator,
     )
 
     with pytest.raises(ValidationError, match="target_system"):
@@ -207,7 +186,7 @@ def test_mapping_group_requires_shared_source_system() -> None:
         "Viking Gp 2",
         "Viking GP.",
         RelationType.alias,
-        source_system=DataSystem.fmu,
+        source_system=DataSystem.simulator,
     )
 
     with pytest.raises(ValidationError, match="source_system"):

--- a/tests/test_resources/test_mappings_manager.py
+++ b/tests/test_resources/test_mappings_manager.py
@@ -549,68 +549,6 @@ def test_build_global_config_stratigraphy_mapped_horizon_not_duplicated(
     assert len(result) == 2  # noqa: PLR2004
 
 
-def test_build_global_config_stratigraphy_equivalent_with_primary_keeps_primary_entry(
-    fmu_dir: ProjectFMUDirectory,
-) -> None:
-    """Equivalent mappings should not change the matching primary entry."""
-    mappings_manager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(
-            root=[
-                StratigraphyIdentifierMapping(
-                    source_system=DataSystem.rms,
-                    target_system=DataSystem.smda,
-                    relation_type=RelationType.primary,
-                    source_id="TopX",
-                    target_id="X Fm. Top",
-                ),
-                StratigraphyIdentifierMapping(
-                    source_system=DataSystem.rms,
-                    target_system=DataSystem.smda,
-                    relation_type=RelationType.equivalent,
-                    source_id="X Fm. Top",
-                    target_id="X Fm. Top",
-                ),
-            ]
-        )
-    )
-
-    strat = mappings_manager.build_global_config_stratigraphy()
-
-    result = strat.model_dump(mode="json", exclude_none=True, exclude_unset=True)
-    assert result == {"TopX": {"stratigraphic": True, "name": "X Fm. Top"}}
-
-
-def test_build_global_config_stratigraphy_equivalent_only_mapping_is_kept(
-    fmu_dir: ProjectFMUDirectory,
-) -> None:
-    """Equivalent-only mappings should still yield a stratigraphic entry."""
-    mappings_manager = MappingsManager(fmu_dir)
-    mappings_manager.update_stratigraphy_mappings(
-        StratigraphyMappings(
-            root=[
-                StratigraphyIdentifierMapping(
-                    source_system=DataSystem.rms,
-                    target_system=DataSystem.smda,
-                    relation_type=RelationType.equivalent,
-                    source_id="X Fm. Top",
-                    target_id="X Fm. Top",
-                ),
-            ]
-        )
-    )
-
-    strat = mappings_manager.build_global_config_stratigraphy()
-
-    result = strat.model_dump(mode="json", exclude_none=True, exclude_unset=True)
-    assert result == {
-        "X Fm. Top": {
-            "stratigraphic": True,
-            "name": "X Fm. Top",
-        }
-    }
-
-
 def test_build_global_config_stratigraphy_correct_drogon_integration(
     drogon_fmu_dir: ProjectFMUDirectory,
 ) -> None:


### PR DESCRIPTION
Resolves #242 

Remove any references to `equivalent` as RelationType for a mapping as this has now been as a RelationType in `fmu-datamodels`.

## Checklist

- [X] Tests added (if not, comment why): Tests adjusted
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
