### PR TITLE
DOC: Improve README architecture overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,200 @@
+# Architecture
+
+This page describes the architecture owned by this repository and the high-level relationship between `fmu-settings` and the surrounding FMU Settings repositories.
+
+`fmu-settings` is the behavioral core. It knows what a project `.fmu/` directory is and how to lock, diff, cache, restore, and validate its managed resources.
+
+## Ecosystem Overview
+
+```mermaid
+flowchart LR
+    CLI["fmu-settings-cli\nTyper launcher"]
+    API["fmu-settings-api\nFastAPI backend"]
+    GUI["fmu-settings-gui\nReact SPA + Python static host"]
+    LIB["fmu-settings\nCore .fmu library"]
+    MODELS["fmu-datamodels\nShared Pydantic domain models"]
+
+    CLI -->|starts API and GUI processes\ncreates bootstrap token| API
+    CLI -->|starts static GUI host\nopens browser URL| GUI
+    CLI -->|uses init/find/sync/copy helpers| LIB
+    CLI -->|loads global configuration models| MODELS
+
+    GUI -->|generated OpenAPI client\nwith cookie session| API
+
+    API -->|reads/writes .fmu resources\nlock/cache/changelog/session flows| LIB
+    API -->|reuses typed domain models\nfor masterdata, mappings, RMS payloads| MODELS
+
+    LIB -->|embeds masterdata, access, model,\nstratigraphy and mapping schemas| MODELS
+```
+
+The dependency chain is intentionally layered:
+
+- [`fmu-settings`](https://github.com/equinor/fmu-settings) owns `.fmu/` directory behavior and core resource workflows.
+- [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides the shared vocabulary for masterdata, access, global configuration, and mappings.
+- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) wraps the core library in a session-oriented application layer.
+- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) talks to the API and should not edit `.fmu/` files directly.
+- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) is the local orchestrator for bootstrapping user state, launching the API and GUI, and running utility commands.
+
+## Core Library
+
+```mermaid
+classDiagram
+    class FMUDirectoryBase {
+        +base_path: Path
+        +path: Path
+        +config
+        +cache: CacheManager
+        +get_config_value(key, default)
+        +set_config_value(key, value)
+        +update_config(updates)
+        +read_text_file(relative_path)
+        +write_text_file(relative_path, content)
+        +list_restorable_files()
+        +restore()
+    }
+
+    class ProjectFMUDirectory {
+        +changelog: ChangelogManager
+        +mappings: MappingsManager
+        +find_rms_projects()
+        +get_dir_diff(new_fmu_dir)
+        +sync_dir(new_fmu_dir)
+        +restore_from_cache(relative_path, revision_id)
+        +get_cache_content(relative_path, revision_id)
+    }
+
+    class UserFMUDirectory
+
+    class CacheManager
+    class LockManager {
+        +acquire()
+        +ensure_can_write()
+        +refresh()
+        +release()
+        +is_acquired()
+    }
+
+    class PydanticResourceManager~PydanticResource~ {
+        +load(force, store_cache)
+        +save(model)
+        +get_resource_diff(incoming_resource)
+        +get_structured_model_diff(current_model, incoming_model)
+    }
+
+    class MutablePydanticResourceManager~MutablePydanticResource~ {
+        +get(key, default)
+        +set(key, value)
+        +update(updates)
+        +reset()
+        +merge_changes(changes)
+    }
+
+    class ProjectConfigManager {
+        +relative_path = config.json
+        +save(model)
+        +set(key, value)
+        +update(updates)
+    }
+
+    class UserConfigManager {
+        +relative_path = config.json
+        +save(model)
+    }
+
+    class MappingsManager {
+        +relative_path = mappings.json
+        +update_stratigraphy_mappings(...)
+        +update_wellbore_mappings(...)
+        +read_rms_eclipse_csv(...)
+        +write_rms_eclipse_csv(...)
+    }
+
+    class ChangelogManager
+    class LogManager~Log~ {
+        +add_log_entry(log_entry)
+        +filter_log(filter)
+    }
+    class UserSessionLogManager
+
+    FMUDirectoryBase <|-- ProjectFMUDirectory
+    FMUDirectoryBase <|-- UserFMUDirectory
+
+    PydanticResourceManager <|-- MutablePydanticResourceManager
+    MutablePydanticResourceManager <|-- ProjectConfigManager
+    MutablePydanticResourceManager <|-- UserConfigManager
+    PydanticResourceManager <|-- LockManager
+    PydanticResourceManager <|-- MappingsManager
+    PydanticResourceManager <|-- LogManager
+    LogManager <|-- UserSessionLogManager
+
+    FMUDirectoryBase *-- LockManager
+    FMUDirectoryBase *-- CacheManager
+    ProjectFMUDirectory *-- ProjectConfigManager
+    ProjectFMUDirectory *-- ChangelogManager
+    ProjectFMUDirectory *-- MappingsManager
+    UserFMUDirectory *-- UserConfigManager
+```
+
+The main library split is:
+
+- `FMUDirectoryBase` is the filesystem-centered abstraction. It owns the `.fmu` path, lock manager, cache manager, and generic read/write helpers.
+- `ProjectFMUDirectory` and `UserFMUDirectory` specialize the base class for project-local `.fmu/` directories and `$HOME/.fmu/`.
+- `PydanticResourceManager` is the generic resource engine for loading, saving, diffing, and caching JSON-backed Pydantic models.
+- `MutablePydanticResourceManager` adds dot-notation `get`, `set`, `update`, `reset`, and merge behavior for editable resources.
+- `ProjectConfigManager`, `UserConfigManager`, `MappingsManager`, and `LogManager` bind specific Pydantic models to managed files inside `.fmu/`.
+- Directory objects compose the correct managers and delegate resource operations to them.
+
+## Runtime Flow
+
+The full runtime spans multiple repositories, but this repository owns the `.fmu/` directory operations used by the API and CLI.
+
+When a user runs `fmu settings`, the CLI starts a local application stack around this library:
+
+1. The CLI ensures the user-level `.fmu/` directory exists, creating `$HOME/.fmu/` through `init_user_fmu_directory()` when needed.
+2. It creates a short-lived bootstrap token used only to authenticate the browser session startup.
+3. It starts the API process and gives it the bootstrap token and runtime settings.
+4. It starts the GUI static-file host.
+5. It opens the browser on the local GUI URL with the bootstrap token in the URL fragment.
+6. The React app reads the token from the fragment, stores it in browser session storage, and exchanges it for an API session.
+7. The API verifies the bootstrap token, ensures user settings are available, creates or renews a server-side session, and sets an HttpOnly session cookie.
+8. If the command was launched from inside an initialized FMU project, the API locates the nearest project `.fmu/` directory and tries to acquire its lock.
+9. After session setup, the GUI talks to the API with the session cookie, and the API uses `ProjectFMUDirectory` and `UserFMUDirectory` to read and write managed resources.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as fmu-settings-cli
+    participant GUIHost as GUI static host
+    participant Browser
+    participant SPA as React SPA
+    participant API as fmu-settings-api
+    participant Session as SessionManager
+    participant UserFMU as UserFMUDirectory
+    participant ProjectFMU as ProjectFMUDirectory
+
+    User->>CLI: run `fmu settings`
+    CLI->>UserFMU: init_user_fmu_directory() if needed
+    CLI->>CLI: generate bootstrap auth token
+    CLI->>API: start local API process with token
+    CLI->>GUIHost: start local GUI static-file host
+    CLI->>Browser: open GUI URL with token fragment
+
+    Browser->>GUIHost: request GUI assets
+    GUIHost-->>Browser: serve React SPA
+    Browser->>SPA: load application
+    SPA->>SPA: read token from URL fragment
+    SPA->>SPA: store token in sessionStorage
+    SPA->>API: POST /api/v1/session with x-fmu-settings-api
+
+    API->>API: verify bootstrap token
+    API->>UserFMU: ensure ~/.fmu exists and load user config
+    API->>Session: create or renew session
+    API->>ProjectFMU: find_nearest_fmu_directory() if present
+    API->>ProjectFMU: try acquire project lock
+    API-->>SPA: set HttpOnly session cookie
+
+    SPA->>API: subsequent requests with cookie
+    API->>Session: resolve Session or ProjectSession
+    API->>ProjectFMU: read/write project config, mappings, cache, changelog
+    API->>UserFMU: read/write user config and API keys
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This page describes the architecture owned by this repository and the high-level relationship between `fmu-settings` and the surrounding FMU Settings repositories.
 
-`fmu-settings` is the behavioral core. It knows what a project `.fmu/` directory is and how to lock, diff, cache, restore, and validate its managed resources.
+`fmu-settings` is the behavioral core. It reads, writes, and manages resources in project and user `.fmu/` directories, including locking, diffing, caching, restoring, and validation.
 
 ## Ecosystem Overview
 
@@ -29,11 +29,11 @@ flowchart LR
 
 The dependency chain is intentionally layered:
 
-- [`fmu-settings`](https://github.com/equinor/fmu-settings) owns `.fmu/` directory behavior and core resource workflows.
+- [`fmu-settings`](https://github.com/equinor/fmu-settings) reads, writes, and manages the resources stored in `.fmu/` directories.
 - [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides the shared vocabulary for masterdata, access, global configuration, and mappings.
-- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) wraps the core library in a session-oriented application layer.
+- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) wraps `fmu-settings` in a session-oriented application layer and coordinates interaction with external systems.
 - [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) talks to the API and should not edit `.fmu/` files directly.
-- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) is the local orchestrator for bootstrapping user state, launching the API and GUI, and running utility commands.
+- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) is the user-facing command line interface for bootstrapping user state, launching the API and GUI, and running utility commands.
 
 ## Core Library
 
@@ -146,9 +146,9 @@ The main library split is:
 
 ## Runtime Flow
 
-The full runtime spans multiple repositories, but this repository owns the `.fmu/` directory operations used by the API and CLI.
+The full runtime spans multiple repositories, but `fmu-settings` owns the `.fmu/` directory operations used by the API and CLI.
 
-When a user runs `fmu settings`, the CLI starts a local application stack around this library:
+When a user runs `fmu settings`, `fmu-settings-cli` starts a local application stack around `fmu-settings`:
 
 1. The CLI ensures the user-level `.fmu/` directory exists, creating `$HOME/.fmu/` through `init_user_fmu_directory()` when needed.
 2. It creates a short-lived bootstrap token used only to authenticate the browser session startup.
@@ -158,7 +158,7 @@ When a user runs `fmu settings`, the CLI starts a local application stack around
 6. The React app reads the token from the fragment, stores it in browser session storage, and exchanges it for an API session.
 7. The API verifies the bootstrap token, ensures user settings are available, creates or renews a server-side session, and sets an HttpOnly session cookie.
 8. If the command was launched from inside an initialized FMU project, the API locates the nearest project `.fmu/` directory and tries to acquire its lock.
-9. After session setup, the GUI talks to the API with the session cookie, and the API uses `ProjectFMUDirectory` and `UserFMUDirectory` to read and write managed resources.
+9. After session setup, the GUI talks to the API with the session cookie, and the API uses `ProjectFMUDirectory` and `UserFMUDirectory` from `fmu-settings` to read and write managed resources.
 
 ```mermaid
 sequenceDiagram
@@ -168,9 +168,9 @@ sequenceDiagram
     participant Browser
     participant SPA as React SPA
     participant API as fmu-settings-api
-    participant Session as SessionManager
-    participant UserFMU as UserFMUDirectory
-    participant ProjectFMU as ProjectFMUDirectory
+    participant Session as SessionManager<br/>fmu-settings-api
+    participant UserFMU as UserFMUDirectory<br/>fmu-settings
+    participant ProjectFMU as ProjectFMUDirectory<br/>fmu-settings
 
     User->>CLI: run `fmu settings`
     CLI->>UserFMU: init_user_fmu_directory() if needed

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 **Source code**: <a href="https://github.com/equinor/fmu-settings/" target="_blank">https://github.com/equinor/fmu-settings/</a>
 
-`fmu-settings` is the Python core library for managing `.fmu/` directories in FMU projects and user environments.
+`fmu-settings` is the Python core library for reading, writing, and managing resources in `.fmu/` directories for FMU projects and user environments.
 
-It owns the filesystem behavior around project settings: initialization, discovery, configuration models, resource managers, locking, cache handling, changelogs, restore behavior, and synchronization helpers.
+It owns the filesystem behavior around those resources: initialization, discovery, configuration models, resource managers, locking, cache handling, changelogs, restore behavior, and synchronization helpers.
 
-## Where It Fits
+## FMU Settings Architecture
 
 FMU Settings is split across a few repositories:
 
@@ -32,11 +32,11 @@ flowchart LR
     API --> MODELS
 ```
 
-- [`fmu-settings`](https://github.com/equinor/fmu-settings) is the core `.fmu/` library.
+- [`fmu-settings`](https://github.com/equinor/fmu-settings) is the core library for reading, writing, and managing `.fmu/` resources.
 - [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides shared Pydantic domain models.
-- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) exposes the library through a FastAPI application layer.
+- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) exposes `fmu-settings` through a FastAPI application layer.
 - [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) provides the browser-based user interface.
-- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) bootstraps local user state, launches the API and GUI, and exposes utility commands.
+- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) provides the user-facing command line interface, including commands that bootstrap local user state and launch the API and GUI.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the library architecture and a high-level ecosystem overview.
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,53 @@
 [![ci](https://github.com/equinor/fmu-settings/actions/workflows/ci.yml/badge.svg)](https://github.com/equinor/fmu-settings/actions/workflows/ci.yml)
 [![docs](https://github.com/equinor/fmu-settings/actions/workflows/docs.yml/badge.svg)](https://github.com/equinor/fmu-settings/actions/workflows/docs.yml)
 
----
-
 **Documentation**: <a href="https://equinor.github.io/fmu-settings/" target="_blank">https://equinor.github.io/fmu-settings/</a>
 
-**Source Code**: <a href="https://github.com/equinor/fmu-settings/" target="_blank">https://github.com/equinor/fmu-settings/</a>
+**Source code**: <a href="https://github.com/equinor/fmu-settings/" target="_blank">https://github.com/equinor/fmu-settings/</a>
 
----
+`fmu-settings` is the Python core library for managing `.fmu/` directories in FMU projects and user environments.
 
-**fmu-settings** is a package to manage and interface with `.fmu/`
-directories, where the FMU settings are contained.
+It owns the filesystem behavior around project settings: initialization, discovery, configuration models, resource managers, locking, cache handling, changelogs, restore behavior, and synchronization helpers.
+
+## Where It Fits
+
+FMU Settings is split across a few repositories:
+
+```mermaid
+flowchart LR
+    CLI["fmu-settings-cli"]
+    API["fmu-settings-api"]
+    GUI["fmu-settings-gui"]
+    LIB["fmu-settings"]
+    MODELS["fmu-datamodels"]
+
+    CLI --> API
+    CLI --> GUI
+    CLI --> LIB
+    GUI --> API
+    API --> LIB
+    LIB --> MODELS
+    API --> MODELS
+```
+
+- [`fmu-settings`](https://github.com/equinor/fmu-settings) is the core `.fmu/` library.
+- [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides shared Pydantic domain models.
+- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) exposes the library through a FastAPI application layer.
+- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) provides the browser-based user interface.
+- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) bootstraps local user state, launches the API and GUI, and exposes utility commands.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the library architecture and a high-level ecosystem overview.
+
+## Documentation
+
+The published documentation is the best starting point for users:
+
+- [Overview](https://equinor.github.io/fmu-settings/overview.html)
+- [Getting started](https://equinor.github.io/fmu-settings/getting_started.html)
+- [GUI user guide](https://equinor.github.io/fmu-settings/gui_user_guide.html)
+- [Terminal commands](https://equinor.github.io/fmu-settings/terminal_commands.html)
+
+Documentation sources live under `docs/src/`.
 
 ## Developing
 
@@ -28,7 +65,7 @@ pip install -e ".[dev]"
 git checkout -b some-feature-branch
 ```
 
-Run the tests with
+Run the tests with:
 
 ```sh
 pytest -n auto tests
@@ -44,4 +81,4 @@ ruff format --check
 mypy src tests
 ```
 
-See the [contributing document](CONTRIBUTING.md) for more.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more.


### PR DESCRIPTION
Resolves #257

The README gives only a short package description and development commands, but it does not explain how `fmu-settings` fits with `fmu-settings-api`, `fmu-settings-gui`, `fmu-settings-cli`, and `fmu-datamodels`.

This PR adds a clearer README overview and adds the longer technical context into a `ARCHITECTURE.md`, including the core library structure, related repository links, and a concise explanation of what happens when running `fmu settings`.

## Checklist

- [x] Tests added (if not, comment why): not applicable; documentation-only change.
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`): not applicable; no code paths changed.
- [x] If not squash merging, every commit passes tests: single documentation commit.
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used.
- [x] All debug prints and unnecessary comments removed.
- [x] Docstrings are correct and updated: not applicable; no Python docstrings changed.
- [x] Documentation is updated, if necessary.
- [x] Latest main rebased/merged into branch.
- [ ] Added comments on this PR where appropriate to help reviewers.
- [x] Moved issue status on project board.
- [x] Checked the boxes in this checklist ✅