### PR TITLE
ENH: Expose additional configs to public API

### DIFF
--- a/src/fmu/settings/__init__.py
+++ b/src/fmu/settings/__init__.py
@@ -16,6 +16,8 @@ from ._fmu_dir import (
 from ._init import (
     REQUIRED_FMU_PROJECT_SUBDIRS,
     InvalidFMUProjectPathError,
+    InvalidGlobalConfigurationError,
+    find_global_config,
     init_fmu_directory,
     init_user_fmu_directory,
 )
@@ -49,4 +51,6 @@ __all__ = [
     "REQUIRED_FMU_PROJECT_SUBDIRS",
     "UserFMUDirectory",
     "find_nearest_fmu_directory",
+    "find_global_config",
+    "InvalidGlobalConfigurationError",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,11 @@ from fmu.datamodels.fmu_results.global_configuration import (
 )
 from pytest import MonkeyPatch
 
+from fmu.settings import (
+    REQUIRED_FMU_PROJECT_SUBDIRS,
+    init_fmu_directory,
+    init_user_fmu_directory,
+)
 from fmu.settings._drogon import (
     ACCESS,
     GLOBAL_CONFIG_STRATIGRAPHY,
@@ -45,11 +50,6 @@ from fmu.settings._drogon import (
     create_drogon_fmu_dir,
 )
 from fmu.settings._fmu_dir import ProjectFMUDirectory, UserFMUDirectory
-from fmu.settings._init import (
-    REQUIRED_FMU_PROJECT_SUBDIRS,
-    init_fmu_directory,
-    init_user_fmu_directory,
-)
 from fmu.settings._version import __version__
 from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.models.user_config import UserConfig

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,15 +9,15 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from fmu.settings import __version__
-from fmu.settings._global_config import find_global_config
-from fmu.settings._init import (
+from fmu.settings import (
     REQUIRED_FMU_PROJECT_SUBDIRS,
     InvalidFMUProjectPathError,
-    _create_fmu_directory,
+    __version__,
+    find_global_config,
     init_fmu_directory,
     init_user_fmu_directory,
 )
+from fmu.settings._init import _create_fmu_directory
 from fmu.settings._readme_texts import PROJECT_README_CONTENT, USER_README_CONTENT
 from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.models.user_config import UserConfig
@@ -174,7 +174,7 @@ def test_write_fmu_config_with_global_config(fmuconfig_with_output: Path) -> Non
         (fmuconfig_with_output / dir).mkdir(parents=True, exist_ok=True)
     cfg = find_global_config(fmuconfig_with_output, strict=False)
     assert cfg is not None
-    with patch("fmu.settings._init.find_global_config") as mock_find_global_config:
+    with patch("fmu.settings.find_global_config") as mock_find_global_config:
         fmu_dir = init_fmu_directory(fmuconfig_with_output, global_config=cfg)
 
     mock_find_global_config.assert_not_called()


### PR DESCRIPTION
Add `find_global_config` & `InvalidGlobalConfigurationError` to the public API surface of fmu-settings`.

Closes #253 

## Checklist

- [x] Tests added (if not, comment why)
No need to create new test cases but modify the existing test with the changes. 
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
