### PR TITLE
ENH: Add TopVolantis_BaseVolantis zone mapping

### DIFF
--- a/src/fmu/settings/_drogon/_data.py
+++ b/src/fmu/settings/_drogon/_data.py
@@ -57,6 +57,12 @@ RMS_ZONES: Final[list[dict[str, Any]]] = [
         "stratigraphic_column_name": ["Column"],
     },
     {
+        "name": "TopVolantis_BaseVolantis",
+        "top_horizon_name": "TopVolantis",
+        "base_horizon_name": "BaseVolantis",
+        "stratigraphic_column_name": ["Column_1"],
+    },
+    {
         "name": "Therys",
         "top_horizon_name": "TopTherys",
         "base_horizon_name": "TopVolon",
@@ -148,6 +154,7 @@ GLOBAL_CONFIG_STRATIGRAPHY: Final[dict[str, Any]] = {
     "Therys": {"stratigraphic": True, "name": "Therys Fm."},
     "Volon": {"stratigraphic": True, "name": "Volon Fm."},
     "Below": {"stratigraphic": False, "name": "Below"},
+    "TopVolantis_BaseVolantis": {"stratigraphic": True, "name": "VOLANTIS GP."},
 }
 
 STRATIGRAPHY_MAPPINGS: Final[list[dict[str, Any]]] = [
@@ -230,5 +237,13 @@ STRATIGRAPHY_MAPPINGS: Final[list[dict[str, Any]]] = [
         "source_id": "Volon",
         "target_id": "Volon Fm.",
         "target_uuid": "a6d740be-ef58-4569-9fad-2daf17aa214c",
+    },
+    {
+        "source_system": "rms",
+        "target_system": "smda",
+        "relation_type": "primary",
+        "source_id": "TopVolantis_BaseVolantis",
+        "target_id": "VOLANTIS GP.",
+        "target_uuid": "08d5f9e0-56bc-4956-b0f3-68f2a3047ef9",
     },
 ]


### PR DESCRIPTION
Resolves #265 

Added TopVolantis_BaseVolantis to RMS zone and update it's mapping to Volantis Gp. Not entirely sure about this, see comments in the issue.
<img width="905" height="795" alt="image" src="https://github.com/user-attachments/assets/7f9cb27d-e18f-4e7b-87c7-cf7f20f111ee" />


## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
