### PR TITLE
TST: Fix `find_global_config` to correct path

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -174,7 +174,7 @@ def test_write_fmu_config_with_global_config(fmuconfig_with_output: Path) -> Non
         (fmuconfig_with_output / dir).mkdir(parents=True, exist_ok=True)
     cfg = find_global_config(fmuconfig_with_output, strict=False)
     assert cfg is not None
-    with patch("fmu.settings.find_global_config") as mock_find_global_config:
+    with patch("fmu.settings._init.find_global_config") as mock_find_global_config:
         fmu_dir = init_fmu_directory(fmuconfig_with_output, global_config=cfg)
 
     mock_find_global_config.assert_not_called()


### PR DESCRIPTION
Restore the path target to `fmu.settings._init.find_global_config` so the mock correctly intercepts the call inside `init_fmu_directory`.

Resolves #267 

## Checklist

- [x] Tests added (if not, comment why)
(Just revert a small change. No need of adding test cases)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
