### PR TITLE
ENH: Add changelog entry when project is initialised

### DIFF
--- a/src/fmu/settings/_init.py
+++ b/src/fmu/settings/_init.py
@@ -138,6 +138,8 @@ def init_fmu_directory(
     fmu_dir.write_text_file("README", PROJECT_README_CONTENT)
 
     fmu_dir.config.reset()
+    fmu_dir.changelog.log_init_to_changelog()
+
     if config_data:
         if isinstance(config_data, ProjectConfig):
             config_data = config_data.model_dump()

--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -125,17 +125,17 @@ class ChangelogManager(LogManager[ChangeInfo]):
         )
 
     def log_init_to_changelog(self: Self) -> None:
-        """Logs a change entry indicating that the project .fmu was initialized."""
+        """Logs a change entry indicating that the project was initialized."""
         self.add_log_entry(
             ChangeInfo(
                 timestamp=datetime.now(UTC),
-                change_type=ChangeType.add,
+                change_type=ChangeType.init,
                 user=os.getenv("USER", "unknown"),
                 path=self.fmu_dir.path,
-                change=f"Initialized .fmu directory at '{self.fmu_dir.path}'.",
+                change="Initialized the project",
                 hostname=socket.gethostname(),
-                file=".fmu",
-                key=".fmu",
+                file="Project configurations",
+                key="project_initialization",
             )
         )
 

--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -132,7 +132,7 @@ class ChangelogManager(LogManager[ChangeInfo]):
                 change_type=ChangeType.init,
                 user=os.getenv("USER", "unknown"),
                 path=self.fmu_dir.path,
-                change="Initialized the project",
+                change=f"Initialized .fmu directory at '{self.fmu_dir.path}'.",
                 hostname=socket.gethostname(),
                 file="N/A",
                 key="project_initialization",

--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -124,6 +124,21 @@ class ChangelogManager(LogManager[ChangeInfo]):
             )
         )
 
+    def log_init_to_changelog(self: Self) -> None:
+        """Logs a change entry indicating that the project .fmu was initialized."""
+        self.add_log_entry(
+            ChangeInfo(
+                timestamp=datetime.now(UTC),
+                change_type=ChangeType.add,
+                user=os.getenv("USER", "unknown"),
+                path=self.fmu_dir.path,
+                change=f"Initialized .fmu directory at '{self.fmu_dir.path}'.",
+                hostname=socket.gethostname(),
+                file=".fmu",
+                key=".fmu",
+            )
+        )
+
     def _get_latest_change_timestamp(self: Self) -> datetime:
         """Get the timestamp of the latest change entry in the changelog."""
         return self.load()[-1].timestamp

--- a/src/fmu/settings/_resources/changelog_manager.py
+++ b/src/fmu/settings/_resources/changelog_manager.py
@@ -134,7 +134,7 @@ class ChangelogManager(LogManager[ChangeInfo]):
                 path=self.fmu_dir.path,
                 change="Initialized the project",
                 hostname=socket.gethostname(),
-                file="Project configurations",
+                file="N/A",
                 key="project_initialization",
             )
         )

--- a/src/fmu/settings/models/_enums.py
+++ b/src/fmu/settings/models/_enums.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 class ChangeType(StrEnum):
     """The types of change that can be made on a file."""
 
+    init = "init"
     update = "update"
     remove = "remove"
     add = "add"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -422,6 +422,7 @@ def fmu_dir(fmu_project_root: Path, unix_epoch_utc: datetime) -> ProjectFMUDirec
         fmu_directory = init_fmu_directory(fmu_project_root)
         if fmu_directory.changelog.exists:
             fmu_directory.changelog.path.unlink()
+            fmu_directory.changelog._cache = None
         return fmu_directory
 
 
@@ -474,6 +475,7 @@ def extra_fmu_dir(
         fmu_directory = init_fmu_directory(extra_fmu_path)
         if fmu_directory.changelog.exists:
             fmu_directory.changelog.path.unlink()
+            fmu_directory.changelog._cache = None
         return fmu_directory
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,7 +419,10 @@ def fmu_dir(fmu_project_root: Path, unix_epoch_utc: datetime) -> ProjectFMUDirec
         mock_datetime.now.return_value = unix_epoch_utc
         mock_datetime.datetime.now.return_value = unix_epoch_utc
         mock_cm_datetime.now.return_value = unix_epoch_utc
-        return init_fmu_directory(fmu_project_root)
+        fmu_directory = init_fmu_directory(fmu_project_root)
+        if fmu_directory.changelog.exists:
+            fmu_directory.changelog.path.unlink()
+        return fmu_directory
 
 
 @pytest.fixture(scope="function")
@@ -468,7 +471,10 @@ def extra_fmu_dir(
         mock_datetime.now.return_value = unix_epoch_utc
         mock_datetime.datetime.now.return_value = unix_epoch_utc
         mock_cm_datetime.now.return_value = unix_epoch_utc
-        return init_fmu_directory(extra_fmu_path)
+        fmu_directory = init_fmu_directory(extra_fmu_path)
+        if fmu_directory.changelog.exists:
+            fmu_directory.changelog.path.unlink()
+        return fmu_directory
 
 
 @pytest.fixture

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,6 +19,7 @@ from fmu.settings import (
 )
 from fmu.settings._init import _create_fmu_directory
 from fmu.settings._readme_texts import PROJECT_README_CONTENT, USER_README_CONTENT
+from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.models.user_config import UserConfig
 
@@ -105,6 +106,23 @@ def test_write_fmu_config_roundtrip(fmu_project_root: Path) -> None:
         config_data = json.loads(f.read())
     # Fails if invalid
     ProjectConfig.model_validate(config_data)
+
+
+def test_init_fmu_directory_writes_initial_changelog_entry(
+    fmu_project_root: Path,
+) -> None:
+    """Tests that initializing a project writes an initial changelog entry."""
+    fmu_dir = init_fmu_directory(fmu_project_root)
+
+    changelog = fmu_dir.changelog.load()
+    assert len(changelog) == 1
+
+    init_entry = changelog[0]
+    assert init_entry.change_type == ChangeType.add
+    assert init_entry.path == fmu_dir.path
+    assert init_entry.file == ".fmu"
+    assert init_entry.key == ".fmu"
+    assert init_entry.change == f"Initialized .fmu directory at '{fmu_dir.path}'."
 
 
 def test_init_fmu_directory_rejects_invalid_project_path(tmp_path: Path) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,7 +19,6 @@ from fmu.settings import (
 )
 from fmu.settings._init import _create_fmu_directory
 from fmu.settings._readme_texts import PROJECT_README_CONTENT, USER_README_CONTENT
-from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.project_config import ProjectConfig
 from fmu.settings.models.user_config import UserConfig
 
@@ -111,18 +110,11 @@ def test_write_fmu_config_roundtrip(fmu_project_root: Path) -> None:
 def test_init_fmu_directory_writes_initial_changelog_entry(
     fmu_project_root: Path,
 ) -> None:
-    """Tests that initializing a project writes an initial changelog entry."""
+    """Tests that initialization triggers changelog logging and stores an entry."""
     fmu_dir = init_fmu_directory(fmu_project_root)
 
     changelog = fmu_dir.changelog.load()
     assert len(changelog) == 1
-
-    init_entry = changelog[0]
-    assert init_entry.change_type == ChangeType.add
-    assert init_entry.path == fmu_dir.path
-    assert init_entry.file == ".fmu"
-    assert init_entry.key == ".fmu"
-    assert init_entry.change == f"Initialized .fmu directory at '{fmu_dir.path}'."
 
 
 def test_init_fmu_directory_rejects_invalid_project_path(tmp_path: Path) -> None:

--- a/tests/test_resources/test_changelog_manager.py
+++ b/tests/test_resources/test_changelog_manager.py
@@ -185,7 +185,7 @@ def test_changelog_manager_log_init_to_changelog(
     init_entry = changelog[0]
     assert init_entry.change_type == ChangeType.init
     assert init_entry.path == fmu_dir.path
-    assert init_entry.file == "Project configurations"
+    assert init_entry.file == "N/A"
     assert init_entry.key == "project_initialization"
     assert init_entry.change == "Initialized the project"
 

--- a/tests/test_resources/test_changelog_manager.py
+++ b/tests/test_resources/test_changelog_manager.py
@@ -187,7 +187,7 @@ def test_changelog_manager_log_init_to_changelog(
     assert init_entry.path == fmu_dir.path
     assert init_entry.file == "N/A"
     assert init_entry.key == "project_initialization"
-    assert init_entry.change == "Initialized the project"
+    assert init_entry.change == f"Initialized .fmu directory at '{fmu_dir.path}'."
 
 
 def test_changelog_filter_equal_operator(

--- a/tests/test_resources/test_changelog_manager.py
+++ b/tests/test_resources/test_changelog_manager.py
@@ -171,6 +171,25 @@ def test_changelog_manager_add_invalid_entry_no_file_created(
     assert changelog_resource.exists is False
 
 
+def test_changelog_manager_log_init_to_changelog(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests that init logging writes the expected changelog entry."""
+    changelog_resource: ChangelogManager = ChangelogManager(fmu_dir)
+
+    changelog_resource.log_init_to_changelog()
+
+    changelog = changelog_resource.load()
+    assert len(changelog) == 1
+
+    init_entry = changelog[0]
+    assert init_entry.change_type == ChangeType.init
+    assert init_entry.path == fmu_dir.path
+    assert init_entry.file == "Project configurations"
+    assert init_entry.key == "project_initialization"
+    assert init_entry.change == "Initialized the project"
+
+
 def test_changelog_filter_equal_operator(
     fmu_dir: ProjectFMUDirectory, change_entry_list: list[ChangeInfo]
 ) -> None:


### PR DESCRIPTION
Resolves #264 

A changelog entry has been added when a new project is initialized. 

<img width="1248" height="720" alt="Screenshot 2026-06-05 at 08 44 15" src="https://github.com/user-attachments/assets/9f25645a-edd5-4a7e-9e99-a86bc16dc595" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
