### PR TITLE
ENH: Add schema_version to migratable models

### DIFF
--- a/src/fmu/settings/_drogon/__init__.py
+++ b/src/fmu/settings/_drogon/__init__.py
@@ -6,6 +6,7 @@ from ._data import (
     PROJECT_CONFIG_DICT,
     RMS_COORDINATE_SYSTEM,
     RMS_HORIZONS,
+    RMS_PROJECT,
     RMS_WELLS,
     RMS_ZONES,
     STRATIGRAPHY_MAPPINGS,
@@ -24,4 +25,5 @@ __all__ = [
     "RMS_HORIZONS",
     "RMS_COORDINATE_SYSTEM",
     "RMS_WELLS",
+    "RMS_PROJECT",
 ]

--- a/src/fmu/settings/_drogon/_data.py
+++ b/src/fmu/settings/_drogon/_data.py
@@ -34,7 +34,7 @@ MASTERDATA: Final[dict[str, Any]] = {
 MODEL: Final[dict[str, Any]] = {
     "name": "Drogon",
     "revision": "26.0.0",
-    "description": None,
+    "description": ["Drogon model with revision 26.0.0."],
 }
 
 
@@ -116,18 +116,20 @@ RMS_WELLS: Final[list[dict[str, str | bool]]] = [
 # Yes, this is the actual value in Drogon.
 RMS_COORDINATE_SYSTEM: Final[dict[str, str]] = {"name": "westeros"}
 
+RMS_PROJECT: Final[dict[str, Any]] = {
+    "path": "rms/model/drogon.rms15.0.1.0",
+    "version": "15.0.1.0",
+    "coordinate_system": RMS_COORDINATE_SYSTEM,
+    "zones": RMS_ZONES,
+    "horizons": RMS_HORIZONS,
+    "wells": RMS_WELLS,
+}
+
 PROJECT_CONFIG_DICT: Final[dict[str, Any]] = {
     "masterdata": MASTERDATA,
     "model": MODEL,
     "access": ACCESS,
-    "rms": {
-        "path": "rms/model/drogon.rms15.0.1.0",
-        "version": "15.0.1.0",
-        "coordinate_system": RMS_COORDINATE_SYSTEM,
-        "zones": RMS_ZONES,
-        "horizons": RMS_HORIZONS,
-        "wells": RMS_WELLS,
-    },
+    "rms": RMS_PROJECT,
 }
 
 GLOBAL_CONFIG_STRATIGRAPHY: Final[dict[str, Any]] = {

--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -242,6 +242,9 @@ class InternalWellboreMappings(RootModel[list[InternalWellboreIdentifierMapping]
 class InternalMappings(BaseModel):
     """Represents the .fmu/mappings.json storage schema."""
 
+    schema_version: Literal[1] = 1
+    """The version of the data schema defined by this data model."""
+
     stratigraphy: InternalStratigraphyMappings = Field(
         default_factory=lambda: InternalStratigraphyMappings(root=[])
     )

--- a/src/fmu/settings/models/project_config.py
+++ b/src/fmu/settings/models/project_config.py
@@ -80,6 +80,9 @@ class ProjectConfig(ResettableBaseModel):
     Stored as config.json.
     """
 
+    schema_version: Literal[1] = 1
+    """The version of the data schema defined by this data model."""
+
     version: VersionStr
     created_at: AwareDatetime
     created_by: str

--- a/src/fmu/settings/models/user_config.py
+++ b/src/fmu/settings/models/user_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 import annotated_types
 from pydantic import (
@@ -40,6 +40,9 @@ class UserConfig(ResettableBaseModel):
 
     Stored as config.json.
     """
+
+    schema_version: Literal[1] = 1
+    """The version of the data schema defined by this data model."""
 
     version: VersionStr
     created_at: AwareDatetime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ from fmu.settings._drogon import (
     MODEL,
     RMS_COORDINATE_SYSTEM,
     RMS_HORIZONS,
+    RMS_PROJECT,
     RMS_WELLS,
     RMS_ZONES,
     STRATIGRAPHY_MAPPINGS,
@@ -87,6 +88,7 @@ def fmu_project_root(tmp_path: Path) -> Path:
 def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
     """A dictionary representing a .fmu config."""
     return {
+        "schema_version": 1,
         "version": __version__,
         "created_at": unix_epoch_utc,
         "created_by": "user",
@@ -152,6 +154,12 @@ def rms_wells_list() -> list[dict[str, str | bool]]:
 def rms_coordinate_system() -> dict[str, str]:
     """Example RMS coordinate system."""
     return deepcopy(RMS_COORDINATE_SYSTEM)
+
+
+@pytest.fixture
+def rms_project() -> dict[str, Any]:
+    """Example RMS project."""
+    return deepcopy(RMS_PROJECT)
 
 
 @pytest.fixture
@@ -319,6 +327,30 @@ def config_dict_with_masterdata(
 
 
 @pytest.fixture
+def mocked_project_config_with_all_fields(
+    unix_epoch_utc: datetime,
+    masterdata_dict: dict[str, Any],
+    model_dict: dict[str, Any],
+    access_dict: dict[str, Any],
+    rms_project: dict[str, Any],
+) -> dict[str, Any]:
+    """A dictionary representing a .fmu project config file with all fields set."""
+    return {
+        "schema_version": 1,
+        "version": __version__,
+        "created_at": unix_epoch_utc,
+        "created_by": "user",
+        "last_modified_at": unix_epoch_utc,
+        "last_modified_by": "user",
+        "cache_max_revisions": 5,
+        "masterdata": masterdata_dict,
+        "model": model_dict,
+        "access": access_dict,
+        "rms": rms_project,
+    }
+
+
+@pytest.fixture
 def config_model(config_dict: dict[str, Any]) -> ProjectConfig:
     """A ProjectConfig model representing a .fmu config file."""
     return ProjectConfig.model_validate(config_dict)
@@ -344,6 +376,22 @@ def user_config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
             "smda_subscription": None,
         },
         "recent_project_directories": [],
+    }
+
+
+@pytest.fixture
+def mocked_user_config_with_all_fields(unix_epoch_utc: datetime) -> dict[str, Any]:
+    """A dictionary representing a .fmu user config file with all fields set."""
+    return {
+        "schema_version": 1,
+        "version": __version__,
+        "created_at": unix_epoch_utc,
+        "last_modified_at": unix_epoch_utc,
+        "cache_max_revisions": 5,
+        "user_api_keys": {
+            "smda_subscription": "very_secret_string",
+        },
+        "recent_project_directories": ["/a/project/path"],
     }
 
 
@@ -436,3 +484,55 @@ def user_fmu_dir(tmp_path: Path, unix_epoch_utc: datetime) -> UserFMUDirectory:
         mock_cm_datetime.now.return_value = unix_epoch_utc
 
         return init_user_fmu_directory()
+
+
+@pytest.fixture
+def mocked_internal_mappings_with_all_fields() -> dict[str, Any]:
+    """A dictionary representing a .fmu mappings file with all fields set."""
+    return {
+        "schema_version": 1,
+        "stratigraphy": [
+            {
+                "source_system": "rms",
+                "target_system": "rms",
+                "mapping_type": "stratigraphy",
+                "relation_type": "primary",
+                "source_id": "TopVolantis",
+                "source_uuid": "00000000-0000-0000-0000-000000000000",
+                "target_id": "TopVolantis",
+                "target_uuid": "00000000-0000-0000-0000-000000000000",
+            },
+            {
+                "source_system": "rms",
+                "target_system": "smda",
+                "mapping_type": "stratigraphy",
+                "relation_type": "primary",
+                "source_id": "TopVolantis",
+                "source_uuid": "00000000-0000-0000-0000-000000000000",
+                "target_id": "VOLANTIS GP. Top",
+                "target_uuid": "00000000-0000-0000-0000-000000000000",
+            },
+        ],
+        "wellbore": [
+            {
+                "source_system": "rms",
+                "target_system": "rms",
+                "mapping_type": "wellbore",
+                "relation_type": "primary",
+                "source_id": "30_9-B-43_A",
+                "source_uuid": "00000000-0000-0000-0000-000000000000",
+                "target_id": "30_9-B-43_A",
+                "target_uuid": "00000000-0000-0000-0000-000000000000",
+            },
+            {
+                "source_system": "rms",
+                "target_system": "simulator",
+                "mapping_type": "wellbore",
+                "relation_type": "primary",
+                "source_id": "30_9-B-43_A",
+                "source_uuid": "00000000-0000-0000-0000-000000000000",
+                "target_id": "B43A",
+                "target_uuid": "00000000-0000-0000-0000-000000000000",
+            },
+        ],
+    }

--- a/tests/test_resources/test_migratable_models_up_to_date.py
+++ b/tests/test_resources/test_migratable_models_up_to_date.py
@@ -1,0 +1,167 @@
+"""Tests for the migratable data models."""
+
+import copy
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, RootModel
+
+from fmu.settings.models.mappings import InternalMappings
+from fmu.settings.models.project_config import ProjectConfig
+from fmu.settings.models.user_config import UserConfig
+
+
+def _all_recursive_fields_set(obj: BaseModel) -> bool:
+    """Checks whether all recursive fields in a given BaseModel object are set.
+
+    Check that all recursive fields for a given BaseModel are set to a
+    value different to None or empty list.
+    """
+    if isinstance(obj, BaseModel):
+        if isinstance(obj, RootModel):
+            return _all_recursive_fields_set(obj.root)
+        return all(_all_recursive_fields_set(value) for value in obj.__dict__.values())
+    if isinstance(obj, list):
+        if len(obj) == 0:
+            return False
+        return all(_all_recursive_fields_set(value) for value in obj)
+    if hasattr(obj, "__dict__"):
+        if isinstance(obj, Enum):
+            return obj is not None
+        return all(_all_recursive_fields_set(value) for value in obj.__dict__.values())
+    return obj is not None
+
+
+def test_project_config_model_needs_migration(
+    mocked_project_config_with_all_fields: dict[str, Any],
+) -> None:
+    """Checks that the project config model does not need migration.
+
+    Check that the current state of the project config model has not changed
+    and needs a new version and migration script.
+
+    The check is performed in two steps:
+    1. Validate that the mocked project config file validates against the current model
+    2. Assert that all optional fields are set to assure the full model is validated
+
+    If step 1 fails:
+        This indicates that the ProjectConfig model has been updated. This requires
+        a bump in the ProjectConfig version from n to n+1, in addition to a new
+        migration script, defining how to migrate from version n to n+1. The mocked
+        project config file should be updated accordingly.
+    If step 2 fails:
+        This indicates that the mocked project config file being used does not have all
+        optional fields set. This is needed in order to get a complete check.
+    """
+    assert set(mocked_project_config_with_all_fields) == set(ProjectConfig.model_fields)
+    project_config = ProjectConfig.model_validate(mocked_project_config_with_all_fields)
+    assert _all_recursive_fields_set(project_config)
+
+
+def test_user_config_model_needs_migration(
+    mocked_user_config_with_all_fields: dict[str, Any],
+) -> None:
+    """Checks that the user config model does not need migration.
+
+    Check that the current state of the user config model has not changed
+    and needs a new version and migration script.
+
+    The check is performed in two steps:
+    1. Validate that the mocked user config file validates against the current model
+    2. Assert that all optional fields are set to assure the full model is validated
+
+    If step 1 fails:
+        This indicates that the UserConfig model has been updated. This requires
+        a bump in the UserConfig version from n to n+1, in addition to a new
+        migration script, defining how to migrate from version n to n+1. The mocked
+        user config file should be updated accordingly.
+    If step 2 fails:
+        This indicates that the mocked user config file being used does not have all
+        optional fields set. This is needed in order to get a complete check.
+    """
+    assert set(mocked_user_config_with_all_fields) == set(UserConfig.model_fields)
+    user_config = UserConfig.model_validate(mocked_user_config_with_all_fields)
+    assert _all_recursive_fields_set(user_config)
+
+
+def test_internal_mappings_model_needs_migration(
+    mocked_internal_mappings_with_all_fields: dict[str, Any],
+) -> None:
+    """Checks that the internal mappings model does not need migration.
+
+    Check that the current state of the internal mappings model has not changed
+    and needs a new version and migration script.
+
+    The check is performed in two steps:
+    1. Validate that the mocked mappings file validates against the current model
+    2. Assert that all optional fields are set to assure the full model is validated
+
+    If step 1 fails:
+        This indicates that the InternalMappings model has been updated. This requires
+        a bump in the InternalMappings version from n to n+1, in addition to a new
+        migration script, defining how to migrate from version n to n+1. The mocked
+        mappings file should be updated accordingly.
+    If step 2 fails:
+        This indicates that the mocked mappings file being used does not have all
+        optional fields set. This is needed in order to get a complete check.
+    """
+    assert set(mocked_internal_mappings_with_all_fields) == set(
+        InternalMappings.model_fields
+    )
+    mappings = InternalMappings.model_validate(mocked_internal_mappings_with_all_fields)
+    assert _all_recursive_fields_set(mappings)
+
+
+def test_all_recursive_fields_set_returns_false_when_field_is_none(
+    mocked_project_config_with_all_fields: dict[str, Any],
+) -> None:
+    """Verify that a data object containing a None value is flagged correctly.
+
+    Tests that the _all_recursive_fields_set method works as intended and returns
+    False when a value in the data object is set to None.
+    """
+    project_config_dict_no_masterdata = copy.deepcopy(
+        mocked_project_config_with_all_fields
+    )
+    project_config_dict_no_masterdata["masterdata"] = None
+    project_config_no_masterdata = ProjectConfig.model_validate(
+        project_config_dict_no_masterdata
+    )
+    assert _all_recursive_fields_set(project_config_no_masterdata) is False
+
+    project_config_dict_no_model_description = copy.deepcopy(
+        mocked_project_config_with_all_fields
+    )
+    project_config_dict_no_model_description["model"]["description"] = None
+    project_config_no_model_description = ProjectConfig.model_validate(
+        project_config_dict_no_model_description
+    )
+    assert _all_recursive_fields_set(project_config_no_model_description) is False
+
+
+def test_all_recursive_fields_set_returns_false_when_empty_list_value(
+    mocked_project_config_with_all_fields: dict[str, Any],
+    mocked_internal_mappings_with_all_fields: dict[str, Any],
+) -> None:
+    """Verify that a data object containing an empty list value is flagged correctly.
+
+    Tests that the _all_recursive_fields_set method works as intended and returns
+    False when a value in the data object is an empty list.
+    """
+    project_config_dict_empty_discovery_list = copy.deepcopy(
+        mocked_project_config_with_all_fields
+    )
+    project_config_dict_empty_discovery_list["masterdata"]["smda"]["discovery"] = []
+    project_config_empty_country_list = ProjectConfig.model_validate(
+        project_config_dict_empty_discovery_list
+    )
+    assert _all_recursive_fields_set(project_config_empty_country_list) is False
+
+    mappings_dict_empty_wellbore_list = copy.deepcopy(
+        mocked_internal_mappings_with_all_fields
+    )
+    mappings_dict_empty_wellbore_list["wellbore"] = []
+    mappings_empty_wellbore_list = InternalMappings.model_validate(
+        mappings_dict_empty_wellbore_list
+    )
+    assert _all_recursive_fields_set(mappings_empty_wellbore_list) is False


### PR DESCRIPTION
Resolves #248 

Add a new field `schema_version ` to the migratabale data models in `.fmu` indentified to be:
* ProjectConfig
* UserConfig
* InternalMappings

The `schema_version ` is set to 1 as this is the first version. It defaults to 1 if this field does not exist to handle existing files without this field.

In addition, tests have been added to check whether any of the migratable models needs migration. This also checks the underlying data models imported from other repos (e.g. Masterdata from fmu-datamodels) as a change here would would also require a migration.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
