### PR TITLE
MAINT:Improved readabilty and add tests log restore events

### DIFF
--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -382,18 +382,23 @@ class ProjectFMUDirectory(FMUDirectoryBase):
         return files
 
     def restore(self: Self) -> list[Path]:
-        """Attempt to reconstruct missing project .fmu files from in-memory state."""
+        """Attempt to reconstruct missing project .fmu files from in-memory state.
+
+        The restore sequence is:
+        1. Delegate config (and README) restore to the base class.
+        2. Log the config restore to the changelog immediately, suppressing any write
+           errors so that a changelog failure cannot prevent the mappings restore.
+        3. Restore the mappings file from in-memory state (if applicable).
+        4. Log the mappings restore to the changelog.
+
+        Returns:
+            List of relative paths that were restored.
+        """
         config_had_cache = getattr(self.config, "_cache", None) is not None
         restorable_files = super().restore()
-        restore_logs: list[tuple[Path, str]] = []
 
         if self.config.relative_path in restorable_files:
-            config_source = (
-                "in-memory session state"
-                if config_had_cache
-                else "default configuration"
-            )
-            restore_logs.append((self.config.relative_path, config_source))
+            self._log_config_restore_to_changelog(config_had_cache)
 
         mappings_path = self.mappings.path
         if self.mappings.relative_path in restorable_files:
@@ -403,17 +408,29 @@ class ProjectFMUDirectory(FMUDirectoryBase):
                 logger.info(
                     f"Restored mappings.json from cached model at {mappings_path}"
                 )
-                restore_logs.append(
-                    (self.mappings.relative_path, "in-memory session state")
+                self.changelog.log_restore_to_changelog(
+                    relative_path=self.mappings.relative_path,
+                    source="in-memory session state",
                 )
 
-        for relative_path, source in restore_logs:
-            self.changelog.log_restore_to_changelog(
-                relative_path=relative_path,
-                source=source,
-            )
-
         return restorable_files
+
+    def _log_config_restore_to_changelog(self: Self, config_had_cache: bool) -> None:
+        """Log config restore without blocking subsequent mappings restore."""
+        config_source = (
+            "in-memory session state" if config_had_cache else "default configuration"
+        )
+
+        try:
+            self.changelog.log_restore_to_changelog(
+                relative_path=self.config.relative_path,
+                source=config_source,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to write config restore entry to changelog. "
+                "Continuing with mappings restore."
+            )
 
     def update_config(self: Self, updates: dict[str, Any]) -> ProjectConfig:
         """Updates multiple configuration values at once.

--- a/src/fmu/settings/_fmu_dir.py
+++ b/src/fmu/settings/_fmu_dir.py
@@ -398,7 +398,21 @@ class ProjectFMUDirectory(FMUDirectoryBase):
         restorable_files = super().restore()
 
         if self.config.relative_path in restorable_files:
-            self._log_config_restore_to_changelog(config_had_cache)
+            config_source = (
+                "in-memory session state"
+                if config_had_cache
+                else "default configuration"
+            )
+            try:
+                self.changelog.log_restore_to_changelog(
+                    relative_path=self.config.relative_path,
+                    source=config_source,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to write config restore entry to changelog. "
+                    "Continuing with mappings restore."
+                )
 
         mappings_path = self.mappings.path
         if self.mappings.relative_path in restorable_files:
@@ -414,23 +428,6 @@ class ProjectFMUDirectory(FMUDirectoryBase):
                 )
 
         return restorable_files
-
-    def _log_config_restore_to_changelog(self: Self, config_had_cache: bool) -> None:
-        """Log config restore without blocking subsequent mappings restore."""
-        config_source = (
-            "in-memory session state" if config_had_cache else "default configuration"
-        )
-
-        try:
-            self.changelog.log_restore_to_changelog(
-                relative_path=self.config.relative_path,
-                source=config_source,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to write config restore entry to changelog. "
-                "Continuing with mappings restore."
-            )
 
     def update_config(self: Self, updates: dict[str, Any]) -> ProjectConfig:
         """Updates multiple configuration values at once.

--- a/tests/test_fmu_dir.py
+++ b/tests/test_fmu_dir.py
@@ -700,6 +700,71 @@ def test_restore_rebuilds_project_fmu_from_cache(
     assert "in-memory session state" in changelog[1].change
 
 
+def test_restore_logs_config_entry_even_when_mappings_restore_fails(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Config changelog entry is written before mappings restore is attempted.
+
+    If the mappings restore raises an exception, the config restore should still
+    be recorded in the changelog because the two steps are independent.
+    """
+    fmu_dir.update_config({"version": "1.2.3"})
+    fmu_dir.mappings.update_internal_stratigraphy_mappings(
+        _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
+    )
+
+    shutil.rmtree(fmu_dir.path)
+    assert not fmu_dir.path.exists()
+
+    with (
+        patch.object(fmu_dir.mappings, "save", side_effect=RuntimeError("disk full")),
+        pytest.raises(RuntimeError, match="disk full"),
+    ):
+        fmu_dir.restore()
+
+    changelog = fmu_dir.changelog.load()
+    assert len(changelog) == 1
+    assert changelog[0].change_type == ChangeType.restore
+    assert changelog[0].file == CacheResource.config.value
+    assert "in-memory session state" in changelog[0].change
+
+
+def test_restore_mappings_when_config_changelog_write_fails(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Config changelog write failures should not block mappings restore."""
+    fmu_dir.update_config({"version": "1.2.3"})
+    fmu_dir.mappings.update_internal_stratigraphy_mappings(
+        _stratigraphy_mappings("TopVolantis", "VOLANTIS GP. Top")
+    )
+    cached_mappings_dump = json.loads((fmu_dir.path / "mappings.json").read_text())
+
+    shutil.rmtree(fmu_dir.path)
+    assert not fmu_dir.path.exists()
+
+    with patch.object(
+        fmu_dir.changelog,
+        "log_restore_to_changelog",
+        side_effect=[RuntimeError("changelog locked"), None],
+    ) as mock_log_restore:
+        restored_files = fmu_dir.restore()
+
+    assert restored_files == [
+        Path("README"),
+        Path("config.json"),
+        Path("mappings.json"),
+    ]
+    restored_mappings_dump = json.loads((fmu_dir.path / "mappings.json").read_text())
+    assert restored_mappings_dump == cached_mappings_dump
+    assert mock_log_restore.call_count == 2
+    assert mock_log_restore.call_args_list[0].kwargs["relative_path"] == Path(
+        "config.json"
+    )
+    assert mock_log_restore.call_args_list[1].kwargs["relative_path"] == Path(
+        "mappings.json"
+    )
+
+
 def test_restore_resets_when_cache_missing_and_logs_restore(
     fmu_dir: ProjectFMUDirectory,
 ) -> None:


### PR DESCRIPTION
Resolves #280 

The restore flow now logs the config restore event immediately after config restore, before attempting mappings restore, and suppresses config changelog write failures so they do not block mappings restore. The method docstring was updated to explain the restore order, and the config changelog logging was moved into a small helper for readability.

Added/updated tests to verify:

- config restore is logged before mappings restore
- config restore remains logged even if mappings restore fails
- mappings restore still runs if writing the config restore changelog entry fails

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
