### PR TITLE
ENH: Populate uuid in .fmu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "PyYAML",
     "annotated_types", # Dependency in Pydantic also
     "fmu-config",
-    "fmu-datamodels",
+    "fmu-datamodels>=0.23.1", # StratigraphyElement.uuid support
     "pandas",
     "pydantic",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "PyYAML",
     "annotated_types", # Dependency in Pydantic also
     "fmu-config",
-    "fmu-datamodels",
+    "fmu-datamodels>=0.23.1",
     "pandas",
     "pydantic",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "PyYAML",
     "annotated_types", # Dependency in Pydantic also
     "fmu-config",
-    "fmu-datamodels>=0.23.1",
+    "fmu-datamodels",
     "pandas",
     "pydantic",
 ]

--- a/src/fmu/settings/_drogon/_data.py
+++ b/src/fmu/settings/_drogon/_data.py
@@ -145,18 +145,51 @@ GLOBAL_CONFIG_STRATIGRAPHY: Final[dict[str, Any]] = {
         "stratigraphic": True,
         "name": "VOLANTIS GP. Top",
         "alias": ["TopVOLANTIS", "TOP_VOLANTIS"],
+        "uuid": "1629c229-0a2b-4f0a-94f7-dc01b171cb1c",
     },
-    "TopTherys": {"stratigraphic": True, "name": "Therys Fm. Top"},
-    "TopVolon": {"stratigraphic": True, "name": "Volon Fm. Top"},
-    "BaseVolon": {"stratigraphic": True, "name": "Volon Fm. Base"},
-    "BaseVolantis": {"stratigraphic": True, "name": "VOLANTIS GP. Base"},
+    "TopTherys": {
+        "stratigraphic": True,
+        "name": "Therys Fm. Top",
+        "uuid": "0240dc8e-659a-4925-b569-6f1570ba6770",
+    },
+    "TopVolon": {
+        "stratigraphic": True,
+        "name": "Volon Fm. Top",
+        "uuid": "8aeab228-6b92-4875-8b13-2b68a3108c8d",
+    },
+    "BaseVolon": {
+        "stratigraphic": True,
+        "name": "Volon Fm. Base",
+        "uuid": "433bd00d-9cf8-4eec-9a35-8bac0821f07c",
+    },
+    "BaseVolantis": {
+        "stratigraphic": True,
+        "name": "VOLANTIS GP. Base",
+        "uuid": "3c36a234-91e3-4bc5-8642-f32b910c5c6c",
+    },
     "BaseVelmodel": {"stratigraphic": False, "name": "BaseVelmodel"},
     "Above": {"stratigraphic": False, "name": "Above"},
-    "Valysar": {"stratigraphic": True, "name": "Valysar Fm."},
-    "Therys": {"stratigraphic": True, "name": "Therys Fm."},
-    "Volon": {"stratigraphic": True, "name": "Volon Fm."},
+    "Valysar": {
+        "stratigraphic": True,
+        "name": "Valysar Fm.",
+        "uuid": "a9cdeb70-af4f-4e86-a209-4eb124ac096a",
+    },
+    "Therys": {
+        "stratigraphic": True,
+        "name": "Therys Fm.",
+        "uuid": "a21c5998-9506-44d8-b29d-208c817e3a0b",
+    },
+    "Volon": {
+        "stratigraphic": True,
+        "name": "Volon Fm.",
+        "uuid": "a6d740be-ef58-4569-9fad-2daf17aa214c",
+    },
     "Below": {"stratigraphic": False, "name": "Below"},
-    "TopVolantis_BaseVolantis": {"stratigraphic": True, "name": "VOLANTIS GP."},
+    "TopVolantis_BaseVolantis": {
+        "stratigraphic": True,
+        "name": "VOLANTIS GP.",
+        "uuid": "08d5f9e0-56bc-4956-b0f3-68f2a3047ef9",
+    },
 }
 
 STRATIGRAPHY_MAPPINGS: Final[list[dict[str, Any]]] = [

--- a/src/fmu/settings/_resources/mappings_manager.py
+++ b/src/fmu/settings/_resources/mappings_manager.py
@@ -155,26 +155,27 @@ class MappingsManager(PydanticResourceManager[InternalMappings]):
             self.stratigraphy_mappings if self.exists else StratigraphyMappings(root=[])
         )
 
-        primaries: dict[str, str] = {}  # source_id -> target_id
-        aliases_by_target: dict[str, list[str]] = {}  # target_id -> [alias source_ids]
+        aliases_by_target_id: dict[
+            str, list[str]
+        ] = {}  # target_id -> [alias source_ids]
 
         # Stratigraphic entries from stratigraphy mappings
         for mapping in stratigraphy_mappings:
-            if mapping.relation_type == RelationType.primary:
-                primaries[mapping.source_id] = mapping.target_id
-            elif mapping.relation_type == RelationType.alias:
-                aliases_by_target.setdefault(mapping.target_id, []).append(
+            if mapping.relation_type == RelationType.alias:
+                aliases_by_target_id.setdefault(mapping.target_id, []).append(
                     mapping.source_id
                 )
 
-        for source_id, target_id in primaries.items():
-            entry: dict[str, Any] = {
-                "stratigraphic": True,
-                "name": target_id,
-            }
-            if aliases := aliases_by_target.get(target_id):
-                entry["alias"] = aliases
-            stratigraphy[source_id] = entry
+        for mapping in stratigraphy_mappings:
+            if mapping.relation_type == RelationType.primary:
+                entry: dict[str, Any] = {
+                    "stratigraphic": True,
+                    "name": mapping.target_id,
+                    "uuid": mapping.target_uuid,
+                }
+                if aliases := aliases_by_target_id.get(mapping.target_id):
+                    entry["alias"] = aliases
+                stratigraphy[mapping.source_id] = entry
 
         # Non-stratigraphic entries from RMS
         rms_config = self.fmu_dir.get_config_value("rms")

--- a/tests/test_resources/test_mappings_manager.py
+++ b/tests/test_resources/test_mappings_manager.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import pytest
 from fmu.datamodels.context.mappings import (
@@ -34,6 +35,7 @@ def _stratigraphy_mappings(
     source_id: str,
     target_id: str,
     *aliases: str,
+    target_uuid: UUID | None = None,
 ) -> InternalStratigraphyMappings:
     return InternalStratigraphyMappings(
         root=[
@@ -60,6 +62,7 @@ def _stratigraphy_mappings(
                 relation_type=InternalRelationType.primary,
                 source_id=source_id,
                 target_id=target_id,
+                target_uuid=target_uuid,
             ),
         ]
     )
@@ -555,14 +558,21 @@ def test_build_global_config_stratigraphy_only_mappings(
 ) -> None:
     """Only stratigraphic entries when there is no RMS config."""
     mappings_manager = MappingsManager(fmu_dir)
+    target_uuid = UUID("00000000-0000-0000-0000-000000000001")
     mappings_manager.update_internal_stratigraphy_mappings(
-        _stratigraphy_mappings("TopX", "X Fm. Top")
+        _stratigraphy_mappings("TopX", "X Fm. Top", target_uuid=target_uuid)
     )
 
     strat = mappings_manager.build_global_config_stratigraphy()
 
     result = strat.model_dump(mode="json", exclude_none=True, exclude_unset=True)
-    assert result == {"TopX": {"stratigraphic": True, "name": "X Fm. Top"}}
+    assert result == {
+        "TopX": {
+            "stratigraphic": True,
+            "name": "X Fm. Top",
+            "uuid": str(target_uuid),
+        }
+    }
 
 
 def test_build_global_config_stratigraphy_mapped_horizon_not_duplicated(

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ requires-dist = [
     { name = "annotated-types" },
     { name = "autodoc-pydantic", marker = "extra == 'docs'" },
     { name = "fmu-config" },
-    { name = "fmu-datamodels" },
+    { name = "fmu-datamodels", specifier = ">=0.23.1" },
     { name = "furo", marker = "extra == 'docs'" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "myst-parser", marker = "extra == 'docs'" },

--- a/uv.lock
+++ b/uv.lock
@@ -371,14 +371,14 @@ wheels = [
 
 [[package]]
 name = "fmu-datamodels"
-version = "0.23.0"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/91/fafe803ba92639a36635b958cd3fb15df886b7b40d06030cb4a4c4710974/fmu_datamodels-0.23.0.tar.gz", hash = "sha256:27645500e369528584d621f795274a655f478b38bbe47e7b0a395dc78cd49932", size = 439311, upload-time = "2026-06-08T10:24:05.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1c/3e21c1b0f508415c2af87e2f7bdd2e9f5a66a871d18c0baf8ef947854025/fmu_datamodels-0.23.1.tar.gz", hash = "sha256:9008863bd0f1cd934251de56409592412de19c886ed6f5dd2d04d99fe5f89058", size = 440561, upload-time = "2026-06-24T11:58:10.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/f6/b98685f0fcc28e09d8a9cfb1e77cb27a4ad2d9544a3b94feb9bd613dbf05/fmu_datamodels-0.23.0-py3-none-any.whl", hash = "sha256:082361bafc57b17280aa9dd5178256069275ccdfb6f97c37c9b3af642a53525f", size = 58062, upload-time = "2026-06-08T10:24:04.109Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/08a6eb140947d9b4553f59cbc261406a9f6e59a53b4584907d58b328de4d/fmu_datamodels-0.23.1-py3-none-any.whl", hash = "sha256:4ee675e1ee356ebdde86904313c60a2b58bf05a74c70e2f65e09bcdc7ca11ee7", size = 59525, upload-time = "2026-06-24T11:58:08.969Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #285 

Populates stratigraphy UUIDs when building global config stratigraphy.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
