### PR TITLE
ENH: Add project validation metadata

### DIFF
--- a/src/fmu/settings/models/project_config.py
+++ b/src/fmu/settings/models/project_config.py
@@ -80,8 +80,8 @@ class ValidationRecord(BaseModel):
     last_validated_at: AwareDatetime
     """Timestamp when the data was last validated."""
 
-    validated_by: str
-    """User who performed the validation."""
+    last_validated_by: str
+    """User who performed the last validation."""
 
 
 class ProjectValidation(BaseModel):

--- a/src/fmu/settings/models/project_config.py
+++ b/src/fmu/settings/models/project_config.py
@@ -74,6 +74,26 @@ class RmsProject(BaseModel):
     wells: list[RmsWell] | None = None
 
 
+class ValidationRecord(BaseModel):
+    """Metadata for a successful validation of project configuration data."""
+
+    last_validated_at: AwareDatetime
+    """Timestamp when the data was last validated."""
+
+    validated_by: str
+    """User who performed the validation."""
+
+
+class ProjectValidation(BaseModel):
+    """Validation metadata for project configuration data."""
+
+    masterdata_smda: ValidationRecord | None = None
+    """Validation metadata for masterdata checked against SMDA."""
+
+    rms_project: ValidationRecord | None = None
+    """Validation metadata for RMS configuration checked against the RMS project."""
+
+
 class ProjectConfig(ResettableBaseModel):
     """The configuration file in a .fmu directory.
 
@@ -93,6 +113,7 @@ class ProjectConfig(ResettableBaseModel):
     access: Access | None = None
     cache_max_revisions: int = Field(default=5, ge=5)
     rms: RmsProject | None = None
+    validation: ProjectValidation = Field(default_factory=ProjectValidation)
 
     @classmethod
     def reset(cls: type[Self]) -> Self:
@@ -112,4 +133,5 @@ class ProjectConfig(ResettableBaseModel):
             access=None,
             cache_max_revisions=5,
             rms=None,
+            validation=ProjectValidation(),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,11 +354,11 @@ def mocked_project_config_with_all_fields(
         "validation": {
             "masterdata_smda": {
                 "last_validated_at": unix_epoch_utc,
-                "validated_by": "user",
+                "last_validated_by": "user",
             },
             "rms_project": {
                 "last_validated_at": unix_epoch_utc,
-                "validated_by": "user",
+                "last_validated_by": "user",
             },
         },
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,10 @@ def config_dict(unix_epoch_utc: datetime) -> dict[str, Any]:
         "model": None,
         "access": None,
         "rms": None,
+        "validation": {
+            "masterdata_smda": None,
+            "rms_project": None,
+        },
     }
 
 
@@ -347,6 +351,16 @@ def mocked_project_config_with_all_fields(
         "model": model_dict,
         "access": access_dict,
         "rms": rms_project,
+        "validation": {
+            "masterdata_smda": {
+                "last_validated_at": unix_epoch_utc,
+                "validated_by": "user",
+            },
+            "rms_project": {
+                "last_validated_at": unix_epoch_utc,
+                "validated_by": "user",
+            },
+        },
     }
 
 


### PR DESCRIPTION
Resolves #58

Added project config validation metadata so API can record when saved project data was last checked against external/project sources.

This adds:

- `ValidationRecord`, with `last_validated_at` and `last_validated_by`
- `ProjectValidation`, with `masterdata_smda` and `rms_project`
- `ProjectConfig.validation`, defaulting to empty validation metadata

Example serialized shape:

```json
{
  "validation": {
    "masterdata_smda": {
      "last_validated_at": "2026-06-25T10:30:00Z",
      "last_validated_by": "muga"
    },
    "rms_project": {
      "last_validated_at": "2026-06-25T10:31:00Z",
      "last_validated_by": "muga"
    }
  }
}
```

Empty/default shape:

```json
{
  "validation": {
    "masterdata_smda": null,
    "rms_project": null
  }
}
```

The API would fill them like this:
```py
record = ValidationRecord(
    last_validated_at=datetime.now(UTC),
    validated_by=getpass.getuser(),
)

self._fmu_dir.set_config_value(
    "validation.masterdata_smda",
    record.model_dump(),
)
```

## Checklist

- [ ] Tests added (if not, comment why) - just model update
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅