### PR TITLE
DOC: Update single server architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,13 +9,13 @@ This page describes the architecture owned by this repository and the high-level
 ```mermaid
 flowchart LR
     CLI["fmu-settings-cli\nTyper launcher"]
-    API["fmu-settings-api\nFastAPI backend"]
-    GUI["fmu-settings-gui\nReact SPA + Python static host"]
+    API["fmu-settings-api\nFastAPI backend and static-file host"]
+    GUI["fmu-settings-gui\nReact SPA and packaged static assets"]
     LIB["fmu-settings\nCore .fmu library"]
     MODELS["fmu-datamodels\nShared Pydantic domain models"]
 
-    CLI -->|starts API and GUI processes\ncreates bootstrap token| API
-    CLI -->|starts static GUI host\nopens browser URL| GUI
+    CLI -->|starts one application process\ncreates bootstrap token| API
+    CLI -->|gets packaged static directory| GUI
     CLI -->|uses init/find/sync/copy helpers| LIB
     CLI -->|loads global configuration models| MODELS
 
@@ -31,9 +31,9 @@ The dependency chain is intentionally layered:
 
 - [`fmu-settings`](https://github.com/equinor/fmu-settings) reads, writes, and manages the resources stored in `.fmu/` directories.
 - [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides the shared vocabulary for masterdata, access, global configuration, and mappings.
-- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) wraps `fmu-settings` in a session-oriented application layer and coordinates interaction with external systems.
-- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) talks to the API and should not edit `.fmu/` files directly.
-- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) is the user-facing command line interface for bootstrapping user state, launching the API and GUI, and running utility commands.
+- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) wraps `fmu-settings` in a session-oriented application layer, coordinates interaction with external systems, and serves the packaged GUI assets.
+- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) builds and packages the React application, which talks to the API and should not edit `.fmu/` files directly.
+- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) is the user-facing command line interface for bootstrapping user state, launching the combined application, and running utility commands.
 
 ## Core Library
 
@@ -148,23 +148,21 @@ The main library split is:
 
 The full runtime spans multiple repositories, but `fmu-settings` owns the `.fmu/` directory operations used by the API and CLI.
 
-When a user runs `fmu settings`, `fmu-settings-cli` starts a local application stack around `fmu-settings`:
+When a user runs `fmu settings`, `fmu-settings-cli` starts a local application around `fmu-settings`:
 
 1. The CLI ensures the user-level `.fmu/` directory exists, creating `$HOME/.fmu/` through `init_user_fmu_directory()` when needed.
 2. It creates a short-lived bootstrap token used only to authenticate the browser session startup.
-3. It starts the API process and gives it the bootstrap token and runtime settings.
-4. It starts the GUI static-file host.
-5. It opens the browser on the local GUI URL with the bootstrap token in the URL fragment.
-6. The React app reads the token from the fragment, stores it in browser session storage, and exchanges it for an API session.
-7. The API verifies the bootstrap token, ensures user settings are available, creates or renews a server-side session, and sets an HttpOnly session cookie.
-8. If the command was launched from inside an initialized FMU project, the API locates the nearest project `.fmu/` directory and tries to acquire its lock.
-9. After session setup, the GUI talks to the API with the session cookie, and the API uses `ProjectFMUDirectory` and `UserFMUDirectory` from `fmu-settings` to read and write managed resources.
+3. It gets the packaged React static directory from `fmu-settings-gui` and starts one FastAPI/Uvicorn process with the static directory, bootstrap token, and runtime settings.
+4. It opens the browser on the local application URL with the bootstrap token in the URL fragment.
+5. The React app reads the token from the fragment, stores it in browser session storage, and exchanges it for an API session.
+6. The API verifies the bootstrap token, ensures user settings are available, creates or renews a server-side session, and sets an HttpOnly session cookie.
+7. If the command was launched from inside an initialized FMU project, the API locates the nearest project `.fmu/` directory and tries to acquire its lock.
+8. After session setup, the GUI talks to the API with the session cookie, and the API uses `ProjectFMUDirectory` and `UserFMUDirectory` from `fmu-settings` to read and write managed resources.
 
 ```mermaid
 sequenceDiagram
     participant User
     participant CLI as fmu-settings-cli
-    participant GUIHost as GUI static host
     participant Browser
     participant SPA as React SPA
     participant API as fmu-settings-api
@@ -175,12 +173,12 @@ sequenceDiagram
     User->>CLI: run `fmu settings`
     CLI->>UserFMU: init_user_fmu_directory() if needed
     CLI->>CLI: generate bootstrap auth token
-    CLI->>API: start local API process with token
-    CLI->>GUIHost: start local GUI static-file host
-    CLI->>Browser: open GUI URL with token fragment
+    CLI->>CLI: get packaged GUI static directory
+    CLI->>API: start local application with assets and token
+    CLI->>Browser: open application URL with token fragment
 
-    Browser->>GUIHost: request GUI assets
-    GUIHost-->>Browser: serve React SPA
+    Browser->>API: request GUI assets
+    API-->>Browser: serve React SPA
     Browser->>SPA: load application
     SPA->>SPA: read token from URL fragment
     SPA->>SPA: store token in sessionStorage

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ The dependency chain is intentionally layered:
 - [`fmu-settings`](https://github.com/equinor/fmu-settings) reads, writes, and manages the resources stored in `.fmu/` directories.
 - [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides the shared vocabulary for masterdata, access, global configuration, and mappings.
 - [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) wraps `fmu-settings` in a session-oriented application layer, coordinates interaction with external systems, and serves the packaged GUI assets.
-- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) builds and packages the React application, which talks to the API and should not edit `.fmu/` files directly.
+- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) builds and packages the React application, which talks to the API.
 - [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) is the user-facing command line interface for bootstrapping user state, launching the combined application, and running utility commands.
 
 ## Core Library
@@ -148,7 +148,7 @@ The main library split is:
 
 The full runtime spans multiple repositories, but `fmu-settings` owns the `.fmu/` directory operations used by the API and CLI.
 
-When a user runs `fmu settings`, `fmu-settings-cli` starts a local application around `fmu-settings`:
+When a user runs the command `fmu settings`, `fmu-settings-cli` starts a local application around `fmu-settings`:
 
 1. The CLI ensures the user-level `.fmu/` directory exists, creating `$HOME/.fmu/` through `init_user_fmu_directory()` when needed.
 2. It creates a short-lived bootstrap token used only to authenticate the browser session startup.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ FMU Settings is split across a few repositories:
 ```mermaid
 flowchart LR
     CLI["fmu-settings-cli"]
-    API["fmu-settings-api"]
-    GUI["fmu-settings-gui"]
+    API["fmu-settings-api\nAPI and static-file host"]
+    GUI["fmu-settings-gui\nReact source and packaged assets"]
     LIB["fmu-settings"]
     MODELS["fmu-datamodels"]
 
-    CLI --> API
-    CLI --> GUI
+    CLI -->|starts one application process| API
+    CLI -->|gets packaged assets| GUI
     CLI --> LIB
-    GUI --> API
+    GUI -->|browser API calls| API
     API --> LIB
     LIB --> MODELS
     API --> MODELS
@@ -34,9 +34,9 @@ flowchart LR
 
 - [`fmu-settings`](https://github.com/equinor/fmu-settings) is the core library for reading, writing, and managing `.fmu/` resources.
 - [`fmu-datamodels`](https://github.com/equinor/fmu-datamodels) provides shared Pydantic domain models.
-- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) exposes `fmu-settings` through a FastAPI application layer.
-- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) provides the browser-based user interface.
-- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) provides the user-facing command line interface, including commands that bootstrap local user state and launch the API and GUI.
+- [`fmu-settings-api`](https://github.com/equinor/fmu-settings-api) exposes `fmu-settings` through a FastAPI application layer and serves the packaged GUI assets.
+- [`fmu-settings-gui`](https://github.com/equinor/fmu-settings-gui) provides the browser-based user interface and packages its static assets.
+- [`fmu-settings-cli`](https://github.com/equinor/fmu-settings-cli) provides the user-facing command line interface, including commands that bootstrap local user state and launch the combined application.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the library architecture and a high-level ecosystem overview.
 


### PR DESCRIPTION
Part of equinor/fmu-settings-api#433

Updated the ecosystem documentation to show that `fmu-settings-gui` packages the React assets, `fmu-settings-cli` starts one application process, and `fmu-settings-api` serves both the API and frontend.

## Review order

This is an optional documentation-only follow-up. Review the implementation PRs first:

1. [fmu-settings-api#438](https://github.com/equinor/fmu-settings-api/pull/438)
2. [fmu-settings-gui#492](https://github.com/equinor/fmu-settings-gui/pull/492)
3. [fmu-settings-cli#160](https://github.com/equinor/fmu-settings-cli/pull/160)

## Checklist

- [x] Tests added (not applicable: documentation only)
- [x] Test coverage equal or up from main (not applicable: documentation only)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅