### PR TITLE
ENH: Add optional application telemetry

### DIFF
--- a/src/fmu/settings/__init__.py
+++ b/src/fmu/settings/__init__.py
@@ -33,6 +33,7 @@ from .models.mappings import (
     InternalWellboreIdentifierMapping,
     InternalWellboreMappings,
 )
+from .telemetry import Telemetry, configure_telemetry
 
 __all__ = [
     "CacheResource",
@@ -51,7 +52,9 @@ __all__ = [
     "MigrationError",
     "ProjectFMUDirectory",
     "REQUIRED_FMU_PROJECT_SUBDIRS",
+    "Telemetry",
     "UserFMUDirectory",
+    "configure_telemetry",
     "find_nearest_fmu_directory",
     "find_global_config",
     "InvalidGlobalConfigurationError",

--- a/src/fmu/settings/telemetry.py
+++ b/src/fmu/settings/telemetry.py
@@ -1,0 +1,175 @@
+"""Optional telemetry for FMU Settings applications."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime
+from importlib import metadata
+from typing import Any, Final
+from uuid import uuid4
+
+_TELEMETRY_ENTRY_POINT_GROUP: Final[str] = "fmu_settings"
+
+
+def _telemetry_attribute(value: Any) -> str | bool | int | float:
+    """Format structured values so telemetry backends can query them."""
+    if isinstance(value, str | bool | int | float):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return json.dumps(value, default=str, sort_keys=True)
+
+
+class Telemetry:
+    """Send explicit application events through an optional logging handler."""
+
+    def __init__(
+        self,
+        *,
+        app_name: str,
+        app_version: str,
+        environment: str | None,
+        run_id: str,
+        minimum_level: int,
+        handler: logging.Handler | None,
+    ) -> None:
+        """Create telemetry with context shared by all emitted events."""
+        self.run_id = run_id
+        self._handler = handler
+        self._logger = logging.getLogger(f"{app_name.replace('-', '_')}.azure")
+        self._context = {
+            "app_name": app_name,
+            "app_version": app_version,
+            "run_id": run_id,
+        }
+        if environment is not None:
+            self._context["environment"] = environment
+
+        if handler is not None:
+            handler.setLevel(minimum_level)
+            self._logger.addHandler(handler)
+            self._logger.setLevel(minimum_level)
+            self._logger.propagate = False
+
+    def emit(
+        self,
+        event: str,
+        *,
+        level: int = logging.INFO,
+        exc_info: Any = None,
+        **attributes: Any,
+    ) -> None:
+        """Send one application event to the configured telemetry handler.
+
+        Args:
+            event: Name of the event, such as ``request_completed``.
+            level: Python logging level for the event.
+            exc_info: Exception information passed to the logging handler.
+            **attributes: Event-specific values added as telemetry properties.
+                Values that are not basic types are stored as JSON.
+
+        Telemetry errors are ignored so they do not interrupt the application.
+        """
+        if self._handler is None or not self._logger.isEnabledFor(level):
+            return
+
+        try:
+            properties = {
+                "level": logging.getLevelName(level).lower(),
+                **{
+                    key: _telemetry_attribute(value)
+                    for key, value in attributes.items()
+                    if value is not None
+                },
+            }
+            properties.update(self._context)
+            self._logger.log(level, event, extra=properties, exc_info=exc_info)
+        except Exception:
+            return
+
+    def shutdown(self) -> None:
+        """Flush, remove, and close the optional telemetry handler."""
+        if self._handler is None:
+            return
+
+        handler = self._handler
+        self._handler = None
+        try:
+            force_flush = getattr(handler, "force_flush", None)
+            if callable(force_flush):
+                force_flush()
+            else:
+                handler.flush()
+        except Exception as e:
+            print(f"Unexpected telemetry shutdown error: {e}", file=sys.stderr)
+        finally:
+            self._logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception as e:
+                print(f"Unexpected telemetry shutdown error: {e}", file=sys.stderr)
+
+
+def configure_telemetry(
+    *,
+    app_name: str,
+    app_version: str,
+    environment: str | None = None,
+    run_id: str | None = None,
+    minimum_level: int = logging.INFO,
+) -> Telemetry:
+    """Configure optional telemetry for an FMU Settings application.
+
+    The handler is loaded from the ``fmu_settings`` entry-point group. If no
+    handler is available or setup fails, the returned telemetry object does
+    nothing.
+
+    Args:
+        app_name: Name of the application that emits the events.
+        app_version: Version of that application.
+        environment: Optional runtime environment, such as a Komodo version.
+        run_id: Identifier shared by events from one application run. A new
+            UUID is created when this is not provided.
+        minimum_level: Lowest Python logging level sent to the handler.
+
+    Returns:
+        A telemetry object that the application must shut down when it exits.
+    """
+    resolved_run_id = run_id or str(uuid4())
+    try:
+        entry_point = next(
+            iter(metadata.entry_points(group=_TELEMETRY_ENTRY_POINT_GROUP)),
+            None,
+        )
+    except Exception as e:
+        print(f"Telemetry is disabled: {e}", file=sys.stderr)
+        entry_point = None
+
+    handler = None
+    if entry_point is not None:
+        try:
+            handler = entry_point.load()()
+        except Exception as e:
+            print(f"Telemetry is disabled: {e}", file=sys.stderr)
+
+    try:
+        return Telemetry(
+            app_name=app_name,
+            app_version=app_version,
+            environment=environment,
+            run_id=resolved_run_id,
+            minimum_level=minimum_level,
+            handler=handler,
+        )
+    except Exception as e:
+        print(f"Telemetry is disabled: {e}", file=sys.stderr)
+        return Telemetry(
+            app_name=app_name,
+            app_version=app_version,
+            environment=environment,
+            run_id=resolved_run_id,
+            minimum_level=minimum_level,
+            handler=None,
+        )

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,229 @@
+"""Tests for optional application telemetry."""
+
+import logging
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from fmu.settings.telemetry import Telemetry, configure_telemetry
+
+
+class RecordingHandler(logging.Handler):
+    """Store records and lifecycle calls for telemetry tests."""
+
+    def __init__(self) -> None:
+        """Create an empty recording handler."""
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+        self.force_flush_calls = 0
+        self.close_calls = 0
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Store one emitted record."""
+        self.records.append(record)
+
+    def force_flush(self) -> None:
+        """Record a forced flush."""
+        self.force_flush_calls += 1
+
+    def close(self) -> None:
+        """Record close calls."""
+        self.close_calls += 1
+        super().close()
+
+
+def _configure(
+    handler: logging.Handler, minimum_level: int = logging.INFO
+) -> Telemetry:
+    """Configure telemetry with one mocked site plugin."""
+    entry_point = Mock()
+    entry_point.load.return_value.return_value = handler
+    with patch(
+        "fmu.settings.telemetry.metadata.entry_points", return_value=[entry_point]
+    ):
+        return configure_telemetry(
+            app_name="fmu-settings-api",
+            app_version="1.2.3",
+            environment="development",
+            run_id="run-123",
+            minimum_level=minimum_level,
+        )
+
+
+def test_configure_telemetry_without_plugin_returns_noop() -> None:
+    """A missing site plugin returns telemetry that safely accepts events."""
+    with patch("fmu.settings.telemetry.metadata.entry_points", return_value=[]):
+        telemetry = configure_telemetry(
+            app_name="fmu-settings-api",
+            app_version="1.2.3",
+        )
+
+    telemetry.emit("request_completed")
+
+    assert telemetry.run_id
+
+
+def test_emit_adds_context_and_formats_attributes() -> None:
+    """Add shared context, format structured values, and omit `None` values."""
+    handler = RecordingHandler()
+    telemetry = _configure(handler)
+
+    telemetry.emit(
+        "request_completed",
+        path="/api/v1/project",
+        status_code=200,
+        details={"resources": ["config", "access"]},
+        occurred_at=datetime(2026, 8, 12, 10, 0, tzinfo=UTC),
+        optional=None,
+    )
+
+    assert len(handler.records) == 1
+    record = handler.records[0]
+    properties = record.__dict__
+    assert record.name == "fmu_settings_api.azure"
+    assert record.getMessage() == "request_completed"
+    assert properties["app_name"] == "fmu-settings-api"
+    assert properties["app_version"] == "1.2.3"
+    assert properties["environment"] == "development"
+    assert properties["run_id"] == "run-123"
+    assert properties["level"] == "info"
+    assert properties["path"] == "/api/v1/project"
+    assert properties["status_code"] == 200
+    assert properties["details"] == '{"resources": ["config", "access"]}'
+    assert properties["occurred_at"] == "2026-08-12T10:00:00+00:00"
+    assert not hasattr(record, "optional")
+    assert logging.getLogger("fmu_settings_api.azure").propagate is False
+
+    telemetry.shutdown()
+
+
+def test_emit_respects_minimum_level() -> None:
+    """Events below the configured minimum level are not sent."""
+    handler = RecordingHandler()
+    telemetry = _configure(handler, logging.WARNING)
+
+    telemetry.emit("debug_event", level=logging.INFO)
+    telemetry.emit("warning_event", level=logging.WARNING)
+
+    assert [record.getMessage() for record in handler.records] == ["warning_event"]
+    telemetry.shutdown()
+
+
+def test_emit_suppresses_handler_failure() -> None:
+    """A handler failure does not escape from `emit()`."""
+    handler = Mock(spec=logging.Handler)
+    handler.level = logging.NOTSET
+    handler.handle.side_effect = RuntimeError("send failed")
+    telemetry = _configure(handler)
+
+    telemetry.emit("request_completed")
+
+    telemetry.shutdown()
+
+
+def test_plugin_load_failure_returns_noop(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A plugin load failure is reported and returns a no-op."""
+    entry_point = Mock()
+    entry_point.load.side_effect = RuntimeError("setup failed")
+    with patch(
+        "fmu.settings.telemetry.metadata.entry_points", return_value=[entry_point]
+    ):
+        telemetry = configure_telemetry(
+            app_name="fmu-settings-api",
+            app_version="1.2.3",
+        )
+
+    telemetry.emit("request_completed")
+
+    assert "Telemetry is disabled: setup failed" in capsys.readouterr().err
+
+
+def test_entry_point_discovery_failure_returns_noop(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A discovery failure is reported and returns a no-op."""
+    with patch(
+        "fmu.settings.telemetry.metadata.entry_points",
+        side_effect=RuntimeError("discovery failed"),
+    ):
+        telemetry = configure_telemetry(
+            app_name="fmu-settings-api",
+            app_version="1.2.3",
+        )
+
+    telemetry.emit("request_completed")
+
+    assert "Telemetry is disabled: discovery failed" in capsys.readouterr().err
+
+
+def test_shutdown_uses_flush_when_force_flush_is_unavailable() -> None:
+    """Standard logging handlers use their normal flush method."""
+    handler = Mock(spec=logging.Handler)
+    telemetry = _configure(handler)
+
+    telemetry.shutdown()
+
+    handler.flush.assert_called_once_with()
+    handler.close.assert_called_once_with()
+
+
+def test_repeated_shutdown_flushes_closes_and_detaches_handler_once() -> None:
+    """Repeated shutdown calls clean up the handler only once."""
+    handler = RecordingHandler()
+    telemetry = _configure(handler)
+
+    telemetry.shutdown()
+    telemetry.shutdown()
+
+    assert handler.force_flush_calls == 1
+    assert handler.close_calls == 1
+    assert handler not in logging.getLogger("fmu_settings_api.azure").handlers
+
+
+def test_shutdown_closes_handler_when_force_flush_fails(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A flush failure is reported without leaving the handler attached."""
+    handler = RecordingHandler()
+    telemetry = _configure(handler)
+
+    with patch.object(handler, "force_flush", side_effect=RuntimeError("flush failed")):
+        telemetry.shutdown()
+
+    assert (
+        "Unexpected telemetry shutdown error: flush failed" in capsys.readouterr().err
+    )
+    assert handler.close_calls == 1
+    assert handler not in logging.getLogger("fmu_settings_api.azure").handlers
+
+
+def test_shutdown_reports_close_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A close failure is reported after the handler is removed."""
+    handler = RecordingHandler()
+    telemetry = _configure(handler)
+
+    with patch.object(handler, "close", side_effect=RuntimeError("close failed")):
+        telemetry.shutdown()
+
+    assert (
+        "Unexpected telemetry shutdown error: close failed" in capsys.readouterr().err
+    )
+    assert handler not in logging.getLogger("fmu_settings_api.azure").handlers
+
+
+def test_handler_configuration_failure_returns_noop(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A handler configuration failure is reported and returns a no-op."""
+    handler = Mock(spec=logging.Handler)
+    handler.setLevel.side_effect = RuntimeError("invalid handler")
+
+    telemetry = _configure(handler)
+    telemetry.emit("request_completed")
+
+    assert "Telemetry is disabled: invalid handler" in capsys.readouterr().err


### PR DESCRIPTION
Resolves #312 

Added a shared telemetry interface for FMU Settings applications. 

Applications (API and CLI) can now configure optional telemetry through the `fmu_settings` entry-point group and emit explicit events with common context such as application name, version, environment, and run ID.

The telemetry interface:

- Uses standard Python logging handlers.
- Returns a no-op when no site plugin (`fmu-site-configuration`) is installed.
- Formats structured values so telemetry backends can query them.
- Supports a configurable minimum log level.
- Flushes and closes the handler during application shutdown.
- Does not automatically export normal `fmu.settings` diagnostic logs.

Related PRs:

- https://github.com/equinor/fmu-settings-api/pull/448
- https://github.com/equinor/fmu-settings-cli/pull/170
- https://github.com/equinor/fmu-site-configuration/pull/232

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅