### PR TITLE
ENH: Allow RMS wellbores to share SMDA targets

### DIFF
--- a/src/fmu/settings/models/mappings.py
+++ b/src/fmu/settings/models/mappings.py
@@ -307,12 +307,21 @@ def _validate_identifier_mappings_collection(
       of a same-system primary. It is also invalid to add two ``rms -> smda``
       mappings for the same ``source_id``.
 
-    - A cross-system ``target_id`` can be used only once per target system.
+    - A cross-system ``target_id`` can be used only once per target system, except
+      for RMS to SMDA wellbore mappings. Different RMS wellbore names can map to
+      the same SMDA wellbore.
       Example valid mappings::
 
           rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
           rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
           rms -> smda, primary, source_id="TopVolantis", target_id="VOLANTIS GP. Top"
+
+      Example valid RMS to SMDA wellbore mappings::
+
+          rms -> rms, primary, source_id="RFT_30_9-B-21_C", target_id="RFT_30_9-B-21_C"
+          rms -> rms, primary, source_id="MLW_30_9-B-21_C", target_id="MLW_30_9-B-21_C"
+          rms -> smda, primary, source_id="RFT_30_9-B-21_C", target_id="NO 30/9-B-21 C"
+          rms -> smda, primary, source_id="MLW_30_9-B-21_C", target_id="NO 30/9-B-21 C"
 
       Example invalid mappings::
 
@@ -322,7 +331,9 @@ def _validate_identifier_mappings_collection(
           rms -> smda, primary, source_id="Volon", target_id="VOLANTIS GP. Top"
 
     The second cross-system mapping is invalid because one cross-system
-    ``target_id`` cannot be mapped to more than one same-system primary.
+    ``target_id`` cannot be mapped to more than one same-system primary. The
+    exception permits this relationship only for ``wellbore`` mappings from
+    ``rms`` to ``smda``.
     """
     same_system_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
     same_system_primary_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
@@ -368,8 +379,14 @@ def _validate_identifier_mappings_collection(
             )
         cross_system_source_keys.add(cross_system_source_key)
 
-        # A cross-system target_id can only belong to one same-system primary.
-        if mapping.target_id is not None:
+        # RMS wellbore names can share an SMDA wellbore target. Other
+        # cross-system target_ids can only belong to one same-system primary.
+        allows_reused_target_id = (
+            mapping.mapping_type == MappingType.wellbore
+            and mapping.source_system == DataSystem.rms
+            and mapping.target_system == DataSystem.smda
+        )
+        if mapping.target_id is not None and not allows_reused_target_id:
             cross_system_target_key = (
                 mapping.mapping_type,
                 mapping.source_system,

--- a/tests/test_mappings_model.py
+++ b/tests/test_mappings_model.py
@@ -502,26 +502,62 @@ def test_validate_collection_rejects_multiple_cross_system_outcomes() -> None:
         )
 
 
-def test_validate_collection_rejects_reused_cross_system_target_id() -> None:
+@pytest.mark.parametrize(
+    ("mapping_type", "target_system", "source_ids", "shared_target_id"),
+    [
+        (
+            MappingType.stratigraphy,
+            DataSystem.smda,
+            ("TopVolantis", "Volon"),
+            "VOLANTIS GP. Top",
+        ),
+        (
+            MappingType.wellbore,
+            DataSystem.simulator,
+            ("RFT_30_9-B-21_C", "MLW_30_9-B-21_C"),
+            "B21C",
+        ),
+    ],
+)
+def test_validate_collection_rejects_reused_cross_system_target_id(
+    mapping_type: MappingType,
+    target_system: DataSystem,
+    source_ids: tuple[str, str],
+    shared_target_id: str,
+) -> None:
     """A cross-system target identifier can only belong to one primary source."""
-    first_primary = create_stratigraphy_mapping()
-    second_primary = create_stratigraphy_mapping(
-        source_id="Volon",
-        target_id="Volon",
-    )
-    first_mapping = create_stratigraphy_mapping(
+    first_source_id, second_source_id = source_ids
+    first_primary = InternalIdentifierMapping(
         source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
+        target_system=DataSystem.rms,
+        mapping_type=mapping_type,
         relation_type=InternalRelationType.primary,
-        source_id="TopVolantis",
-        target_id="VOLANTIS GP. Top",
+        source_id=first_source_id,
+        target_id=first_source_id,
     )
-    second_mapping = create_stratigraphy_mapping(
+    second_primary = InternalIdentifierMapping(
         source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
+        target_system=DataSystem.rms,
+        mapping_type=mapping_type,
         relation_type=InternalRelationType.primary,
-        source_id="Volon",
-        target_id="VOLANTIS GP. Top",
+        source_id=second_source_id,
+        target_id=second_source_id,
+    )
+    first_mapping = InternalIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=target_system,
+        mapping_type=mapping_type,
+        relation_type=InternalRelationType.primary,
+        source_id=first_source_id,
+        target_id=shared_target_id,
+    )
+    second_mapping = InternalIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=target_system,
+        mapping_type=mapping_type,
+        relation_type=InternalRelationType.primary,
+        source_id=second_source_id,
+        target_id=shared_target_id,
     )
 
     with pytest.raises(
@@ -533,6 +569,44 @@ def test_validate_collection_rejects_reused_cross_system_target_id() -> None:
         mappings_model._validate_identifier_mappings_collection(
             [first_primary, second_primary, first_mapping, second_mapping]
         )
+
+
+def test_wellbore_mappings_allow_reused_rms_to_smda_target_id() -> None:
+    """Different RMS wellbore names can map to the same SMDA wellbore."""
+    rft_primary = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        source_id="RFT_30_9-B-21_C",
+        target_id="RFT_30_9-B-21_C",
+    )
+    mlw_primary = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        source_id="MLW_30_9-B-21_C",
+        target_id="MLW_30_9-B-21_C",
+    )
+    rft_mapping = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        source_id="RFT_30_9-B-21_C",
+        target_id="NO 30/9-B-21 C",
+    )
+    mlw_mapping = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        source_id="MLW_30_9-B-21_C",
+        target_id="NO 30/9-B-21 C",
+    )
+
+    mappings = InternalWellboreMappings(
+        root=[rft_primary, mlw_primary, rft_mapping, mlw_mapping]
+    )
+
+    converted = mappings.to_wellbore_mappings()
+    assert [(mapping.source_id, mapping.target_id) for mapping in converted] == [
+        ("RFT_30_9-B-21_C", "NO 30/9-B-21 C"),
+        ("MLW_30_9-B-21_C", "NO 30/9-B-21 C"),
+    ]
 
 
 def test_validate_collection_rejects_reused_same_system_source_id() -> None:


### PR DESCRIPTION
Resolves #313

Allow multiple RMS wellbore names, such as RFT and MLW, to map to the same SMDA wellbore. `target_id` remain unique for other mapping types and system pairs.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅